### PR TITLE
chore: Upgrade immich to v2.7.4

### DIFF
--- a/kubernetes/apps/immich/immich.yaml
+++ b/kubernetes/apps/immich/immich.yaml
@@ -17,7 +17,7 @@ spec:
       interval: 1m
   values:
     image:
-      tag: v2.6.3
+      tag: v2.7.4
 
     securityContext:
       capabilities:
@@ -82,7 +82,7 @@ spec:
 
     ai:
       image:
-        tag: v2.6.3
+        tag: v2.7.4
       runtimeClass:
         enabled: true
         name: nvidia


### PR DESCRIPTION
This pull request updates the Immich application deployment in Kubernetes to use a newer version of the Immich Docker images. Both the main application and the AI component are upgraded to version 2.7.4.

Version upgrades:

* Updated the main Immich application image tag from `v2.6.3` to `v2.7.4` in `kubernetes/apps/immich/immich.yaml`.
* Updated the AI component image tag from `v2.6.3` to `v2.7.4` in `kubernetes/apps/immich/immich.yaml`.