### PR TITLE
chore: Upgrade pgadmin

### DIFF
--- a/kubernetes/apps/k8s00/admin-tools/pgadmin.yaml
+++ b/kubernetes/apps/k8s00/admin-tools/pgadmin.yaml
@@ -100,7 +100,7 @@ spec:
         fsGroup: 5050
       containers:
         - name: pgadmin
-          image: dpage/pgadmin4:9.13
+          image: dpage/pgadmin4:9.14
           imagePullPolicy: Always
           env:
             - name: PGADMIN_DEFAULT_EMAIL


### PR DESCRIPTION
This pull request updates the `pgadmin` container image in the Kubernetes deployment to use a newer version.

- Dependency update:
  * Upgraded the `pgadmin` container image from version `9.13` to `9.14` in `kubernetes/apps/k8s00/admin-tools/pgadmin.yaml`