### PR TITLE
chore: Upgrade immich

### DIFF
--- a/kubernetes/apps/k8s00/immich/immich.yaml
+++ b/kubernetes/apps/k8s00/immich/immich.yaml
@@ -17,7 +17,7 @@ spec:
       interval: 1m
   values:
     image:
-      tag: v2.7.4
+      tag: v2.7.5
 
     securityContext:
       capabilities:
@@ -82,7 +82,7 @@ spec:
 
     ai:
       image:
-        tag: v2.7.4
+        tag: v2.7.5
       runtimeClass:
         enabled: true
         name: nvidia


### PR DESCRIPTION
This pull request updates the Immich deployment configuration to use the latest image version for both the main application and the AI component.

Version updates:

* Updated the `image.tag` for the main Immich application from `v2.7.4` to `v2.7.5` in `immich.yaml`.
* Updated the `ai.image.tag` for the AI component from `v2.7.4` to `v2.7.5` in `immich.yaml`.