### PR TITLE
chore: Upgrade yarr stack

### DIFF
--- a/kubernetes/apps/k8s00/yarr/bazarr.yaml
+++ b/kubernetes/apps/k8s00/yarr/bazarr.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: bazarr
-          image: lscr.io/linuxserver/bazarr:v1.5.6-ls342
+          image: lscr.io/linuxserver/bazarr:v1.5.6-ls344
           imagePullPolicy: Always
           securityContext:
             capabilities:

--- a/kubernetes/apps/k8s00/yarr/jellyfin.yaml
+++ b/kubernetes/apps/k8s00/yarr/jellyfin.yaml
@@ -30,7 +30,7 @@ spec:
   chart:
     spec:
       chart: jellyfin
-      version: ">= 2.7.0 < 2.8.0"
+      version: ">= 3.2.0 < 3.3.0"
       sourceRef:
         kind: HelmRepository
         name: jellyfin

--- a/kubernetes/apps/k8s00/yarr/jellyseerr.yaml
+++ b/kubernetes/apps/k8s00/yarr/jellyseerr.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: ${groupId}
       containers:
         - name: jellyseerr
-          image: seerr/seerr:v3.1.0
+          image: seerr/seerr:v3.2.0
           imagePullPolicy: Always
           securityContext:
             capabilities:

--- a/kubernetes/apps/k8s00/yarr/prowlarr.yaml
+++ b/kubernetes/apps/k8s00/yarr/prowlarr.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: ${groupId}
       containers:
         - name: prowlarr
-          image: lscr.io/linuxserver/prowlarr:2.3.0.5236-ls139
+          image: lscr.io/linuxserver/prowlarr:2.3.5.5327-ls142
           imagePullPolicy: Always
           securityContext:
             capabilities:

--- a/kubernetes/apps/k8s00/yarr/qbittorrent.yaml
+++ b/kubernetes/apps/k8s00/yarr/qbittorrent.yaml
@@ -75,7 +75,7 @@ spec:
             echo "ping successfull, exiting"
       containers:
         - name: qbittorrent
-          image: lscr.io/linuxserver/qbittorrent:5.1.4-r2-ls446
+          image: lscr.io/linuxserver/qbittorrent:5.1.4-r3-ls450
           imagePullPolicy: Always
           securityContext:
             capabilities:

--- a/kubernetes/apps/k8s00/yarr/radarr.yaml
+++ b/kubernetes/apps/k8s00/yarr/radarr.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: ${groupId}
       containers:
         - name: radarr
-          image: lscr.io/linuxserver/radarr:6.0.4.10291-ls295
+          image: lscr.io/linuxserver/radarr:6.1.1.10360-ls299
           imagePullPolicy: Always
           securityContext:
             capabilities:

--- a/kubernetes/apps/k8s00/yarr/sonarr.yaml
+++ b/kubernetes/apps/k8s00/yarr/sonarr.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: ${groupId}
       containers:
         - name: sonarr
-          image: lscr.io/linuxserver/sonarr:4.0.17.2952-ls305
+          image: lscr.io/linuxserver/sonarr:4.0.17.2952-ls308
           imagePullPolicy: Always
           securityContext:
             capabilities:


### PR DESCRIPTION
This pull request updates several container images and Helm chart versions for applications in the Yarr Kubernetes cluster. The main goal is to ensure that the deployed applications use the latest stable versions, which may include security patches, bug fixes, and new features.

**Container Image Updates:**

* Upgraded `radarr` to version `6.1.1.10360-ls299` for improved stability and features.
* Upgraded `prowlarr` to version `2.3.5.5327-ls142` for the latest enhancements and fixes.
* Upgraded `qbittorrent` to version `5.1.4-r3-ls450` for bug fixes and improvements.
* Upgraded `sonarr` to version `4.0.17.2952-ls308` for incremental improvements.
* Upgraded `bazarr` to version `v1.5.6-ls344` for minor updates.
* Upgraded `jellyseerr` to version `v3.2.0` for new features and bug fixes.

**Helm Chart Update:**

* Updated the `jellyfin` Helm chart version constraint to `>= 3.2.0 < 3.3.0`, allowing deployment of the latest compatible chart.