### PR TITLE
chore: Upgrade cilium to 1.19.3

### DIFF
--- a/kubernetes/infrastructure/k8s00/cilium.yaml
+++ b/kubernetes/infrastructure/k8s00/cilium.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: ">=1.19.2 <1.20.0"
+      version: ">=1.19.3 <1.20.0"
       sourceRef:
         kind: HelmRepository
         name: cilium


### PR DESCRIPTION
This pull request updates the Cilium Helm chart version constraint in the Kubernetes infrastructure configuration to require at least version 1.19.3 (previously 1.19.2), ensuring a newer patch release is used.

- Updated the `cilium` Helm chart version constraint in `kubernetes/infrastructure/k8s00/cilium.yaml` to require version `>=1.19.3 <1.20.0` instead of `>=1.19.2 <1.20.0`.