### PR TITLE
chore: Upgrade cnpg and barman plugin

### DIFF
--- a/kubernetes/infrastructure/k8s00/cnpg/cloudnative-pg.yaml
+++ b/kubernetes/infrastructure/k8s00/cnpg/cloudnative-pg.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cloudnative-pg
-      version: ">=0.27.1 <0.28.0"
+      version: ">=0.28.0 <0.29.0"
       sourceRef:
         kind: HelmRepository
         name: cnpg

--- a/kubernetes/infrastructure/k8s00/cnpg/plugin-barman-cloud.yaml
+++ b/kubernetes/infrastructure/k8s00/cnpg/plugin-barman-cloud.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: plugin-barman-cloud
-      version: ">=0.5.0 <0.6.0"
+      version: ">=0.6.0 <0.7.0"
       sourceRef:
         kind: HelmRepository
         name: cnpg


### PR DESCRIPTION
This pull request updates the Helm chart versions for two components in the CNPG (CloudNativePG) Kubernetes infrastructure. The changes ensure that both the main `cloudnative-pg` chart and the `plugin-barman-cloud` chart use the latest compatible releases.

Helm chart version updates:

* Updated the `cloudnative-pg` chart version constraint to `>=0.28.0 <0.29.0` in `cloudnative-pg.yaml` to allow for newer features and fixes.
* Updated the `plugin-barman-cloud` chart version constraint to `>=0.6.0 <0.7.0` in `plugin-barman-cloud.yaml` to ensure compatibility with the latest plugin release.