### PR TITLE
chore: Upgrade rook-ceph

### DIFF
--- a/kubernetes/infrastructure/k8s00/rook-ceph.yaml
+++ b/kubernetes/infrastructure/k8s00/rook-ceph.yaml
@@ -25,7 +25,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph
-      version: ">=1.19.3 <1.20.0"
+      version: ">=1.19.4 <1.20.0"
       sourceRef:
         kind: HelmRepository
         name: rook-ceph
@@ -45,7 +45,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph-cluster
-      version: ">=1.19.3 <1.20.0"
+      version: ">=1.19.4 <1.20.0"
       sourceRef:
         kind: HelmRepository
         name: rook-ceph


### PR DESCRIPTION
This pull request updates the `rook-ceph` and `rook-ceph-cluster` Helm chart versions in the Kubernetes infrastructure configuration to require at least version 1.19.4. This ensures that deployments use the latest patch release within the 1.19 series, which may include important bug fixes or security updates.

Helm chart version updates:

* Updated the `rook-ceph` chart version constraint to require `>=1.19.4 <1.20.0` in `rook-ceph.yaml`.
* Updated the `rook-ceph-cluster` chart version constraint to require `>=1.19.4 <1.20.0` in `rook-ceph.yaml`.