### PR TITLE
chore: Update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
   #   hooks:
   #     - id: ansible-lint
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.46.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint
         args: ["--fix"]


### PR DESCRIPTION
This pull request updates the `markdownlint-cli` pre-commit hook to use a newer version. This ensures that markdown files will be linted and auto-fixed using the latest rules and bug fixes.

* Upgraded the `markdownlint-cli` pre-commit hook from version `v0.46.0` to `v0.48.0` in `.pre-commit-config.yaml`