### PR TITLE
feat: realign dns logic

### DIFF
--- a/ansible/host_vars/pihole/docker.yaml
+++ b/ansible/host_vars/pihole/docker.yaml
@@ -88,8 +88,8 @@ docker_mgmt:
     - env:
         TZ: "{{ local_timezone }}"
         FTLCONF_webserver_api_password: "{{ admin_password }}"
-        FTLCONF_dns_upstreams: "192.168.0.1"
-        # FTLCONF_dns_upstreams: 192.168.0.8#5353;pihole_k8s00;192.168.0.1
+        FTLCONF_dns_upstreams: "192.168.40.8;192.168.0.1;192.168.0.1#53053"
+        # FTLCONF_dns_upstreams: "192.168.40.8;192.168.0.1"
         FTLCONF_dns_listeningMode: 'all'
         FTLCONF_dns_rateLimit_count: "100000"
         FTLCONF_dns_rateLimit_interval: "15"
@@ -116,8 +116,8 @@ docker_mgmt:
     - env:
         TZ: "{{ local_timezone }}"
         FTLCONF_webserver_api_password: "{{ admin_password }}"
-        FTLCONF_dns_upstreams: "192.168.30.1"
-        # FTLCONF_dns_upstreams: 192.168.30.8#5353;pihole_k8s00;192.168.30.1
+        FTLCONF_dns_upstreams: "192.168.30.1;192.168.30.1#53053"
+        # FTLCONF_dns_upstreams: "192.168.30.1"
         FTLCONF_dns_listeningMode: 'all'
         FTLCONF_dns_rateLimit_count: "100000"
         FTLCONF_dns_rateLimit_interval: "15"
@@ -144,8 +144,8 @@ docker_mgmt:
     - env:
         TZ: "{{ local_timezone }}"
         FTLCONF_webserver_api_password: "{{ admin_password }}"
-        FTLCONF_dns_upstreams: "192.168.40.1"
-        # FTLCONF_dns_upstreams: 192.168.40.8#5353;192.168.40.1
+        FTLCONF_dns_upstreams: "192.168.30.8;192.168.40.1#53053"
+        # FTLCONF_dns_upstreams: "192.168.30.8"
         FTLCONF_dns_listeningMode: 'all'
         FTLCONF_dns_rateLimit_count: "100000"
         FTLCONF_dns_rateLimit_interval: "15"
@@ -176,8 +176,7 @@ docker_mgmt:
     - env:
         TZ: "{{ local_timezone }}"
         FTLCONF_webserver_api_password: "{{ admin_password }}"
-        FTLCONF_dns_upstreams: "192.168.50.1"
-        # FTLCONF_dns_upstreams: 192.168.50.8#5353;pihole_k8s00;192.168.50.1
+        FTLCONF_dns_upstreams: "192.168.30.8"
         FTLCONF_dns_listeningMode: 'all'
         FTLCONF_dns_rateLimit_count: "100000"
         FTLCONF_dns_rateLimit_interval: "15"


### PR DESCRIPTION
This pull request updates the DNS upstream server configuration for multiple Pi-hole Docker containers in the `ansible/host_vars/pihole/docker.yaml` file. The main focus is on modifying the `FTLCONF_dns_upstreams` environment variable to use new or additional upstream DNS servers for different network segments.

**DNS Upstream Configuration Updates:**

* Updated the DNS upstreams for the `192.168.0.x` network to include `192.168.40.8`, `192.168.0.1`, and `192.168.0.1#53053` as upstream servers.
* Changed the DNS upstreams for the `192.168.30.x` network to include both `192.168.30.1` and `192.168.30.1#53053`.
* Modified the DNS upstreams for the `192.168.40.x` network to use `192.168.30.8` and `192.168.40.1#53053`.
* Set the DNS upstream for the `192.168.50.x` network to `192.168.30.8` only, removing previous upstreams.