### PR TITLE
feat: upgrade kubernetes to 1.35.3 and talos to 1.12.7

### DIFF
--- a/kubernetes/starter/k8s00/talos/talconfig.yaml
+++ b/kubernetes/starter/k8s00/talos/talconfig.yaml
@@ -1,7 +1,7 @@
 clusterName: k8s00
 endpoint: https://endpoint.${subdomain}:6443
-kubernetesVersion: "1.34.6"
-talosVersion: v1.12.6
+kubernetesVersion: "1.35.3"
+talosVersion: v1.12.7
 nodes:
   - hostname: cp00.${subdomain}
     ipAddress: cp00.${subdomain}
@@ -73,27 +73,6 @@ nodes:
         dhcpOptions:
           ipv4: true
           # ipv6: true
-  # - hostname: wk04.${subdomain}
-  #   ipAddress: wk04.${subdomain}
-  #   controlPlane: false
-  #   installDisk:
-  #   schematic:
-  #     customization:
-  #       systemExtensions:
-  #         officialExtensions:
-  #           - siderolabs/nvidia-open-gpu-kernel-modules-production
-  #           - siderolabs/nvidia-container-toolkit-production
-  #           - siderolabs/intel-ucode
-  #   kernelModules:
-  #     - name: nvidia
-  #     - name: nvidia_uvm
-  #     - name: nvidia_drm
-  #     - name: nvidia_modeset
-  #   patches:
-  #     - |-
-  #       machine:
-  #         sysctls:
-  #           net.core.bpf_jit_harden: 1
   # - hostname: wk05.${subdomain}
   #   ipAddress: wk05.${subdomain}
   #   controlPlane: false


### PR DESCRIPTION
This pull request updates the Kubernetes and Talos versions in the `talconfig.yaml` configuration file and removes a large commented-out node configuration block. The main focus is on keeping the cluster components up to date and cleaning up unused configuration.

**Version upgrades:**
* Updated `kubernetesVersion` from `"1.34.6"` to `"1.35.3"` in `talconfig.yaml` to ensure the cluster uses the latest Kubernetes features and security patches.
* Updated `talosVersion` from `v1.12.6` to `v1.12.7` in `talconfig.yaml` for Talos OS improvements and bug fixes.

**Configuration cleanup:**
* Removed a large commented-out configuration block for a node (`wk04`) that included GPU and kernel module setup, system extensions, and sysctl settings, simplifying the `nodes` list.