### PR TITLE
feat: upgrade garage to 2.3

### DIFF
--- a/kubernetes/apps/k8s00/garage/garage.yaml
+++ b/kubernetes/apps/k8s00/garage/garage.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 1440m
   url: https://git.deuxfleurs.fr/Deuxfleurs/garage
   ref:
-    semver: "v2.2.*"
+    semver: "v2.3.*"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
This pull request updates the version constraint for the Garage application in the Kubernetes deployment configuration to allow newer releases.

- Deployment configuration update:
  * [`kubernetes/apps/k8s00/garage/garage.yaml`](diffhunk://#diff-8828e901979b473e1949f6cce576bf7f1d5169768f557a3b4e0ad122f9eed5a1L11-R11): Changed the `semver` version constraint from `"v2.2.*"` to `"v2.3.*"` to enable deployment of Garage version 2.3.x releases.