### PR TITLE
feat: upgrade talos to 1.13

### DIFF
--- a/kubernetes/starter/k8s00/talos/talconfig.yaml
+++ b/kubernetes/starter/k8s00/talos/talconfig.yaml
@@ -1,7 +1,7 @@
 clusterName: k8s00
 endpoint: https://endpoint.${subdomain}:6443
 kubernetesVersion: "1.35.3"
-talosVersion: v1.12.7
+talosVersion: v1.13.0
 nodes:
   - hostname: cp00.${subdomain}
     ipAddress: cp00.${subdomain}


### PR DESCRIPTION
This pull request updates the Talos version in the Kubernetes cluster configuration to ensure the environment is using the latest features and security updates.

Configuration update:

* Updated the `talosVersion` in `talconfig.yaml` from `v1.12.7` to `v1.13.0` to keep the cluster up to date.