### PR TITLE
chore: update harbor to 1.19.0

### DIFF
--- a/kubernetes/apps/k8s00/harbor/harbor.yaml
+++ b/kubernetes/apps/k8s00/harbor/harbor.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: harbor
-      version: ">= 1.18.3 < 1.19.0"
+      version: ">= 1.19.0 < 1.20.0"
       sourceRef:
         kind: HelmRepository
         name: harbor


### PR DESCRIPTION
This pull request updates the Harbor Helm chart version constraint in the Kubernetes deployment configuration to allow for newer releases within the 1.19.x series.

- Dependency update:
  * Updated the Harbor Helm chart version constraint in `kubernetes/apps/k8s00/harbor/harbor.yaml` from `>= 1.18.3 < 1.19.0` to `>= 1.19.0 < 1.20.0`, enabling the use of Harbor 1.19.x releases.