### PR TITLE
chore: update kavita to 0.9.0

### DIFF
--- a/kubernetes/apps/k8s00/manga/kavita.yaml
+++ b/kubernetes/apps/k8s00/manga/kavita.yaml
@@ -17,7 +17,7 @@ spec:
       interval: 1m
   values:
     image:
-      tag: 0.8.9
+      tag: 0.9.0
     podSecurityContext:
       fsGroup: ${groupId}
     securityContext:


### PR DESCRIPTION
This pull request updates the `kavita.yaml` deployment configuration to use a newer version of the Kavita image.

- Upgraded the Kavita Docker image tag from `0.8.9` to `0.9.0` in `kubernetes/apps/k8s00/manga/kavita.yaml`