### PR TITLE
chore: update seerr to sha-dfde4d3

### DIFF
--- a/kubernetes/apps/k8s00/yarr/seerr.yaml
+++ b/kubernetes/apps/k8s00/yarr/seerr.yaml
@@ -2,10 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 
 metadata:
-  name: yarr-jellyseerr
+  name: yarr-seerr
   namespace: yarr
   labels:
-    app: jellyseerr
+    app: seerr
 
 spec:
   replicas: 1
@@ -13,17 +13,18 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: jellyseerr
+      app: seerr
   template:
     metadata:
       labels:
-        app: jellyseerr
+        app: seerr
     spec:
       securityContext:
         fsGroup: ${groupId}
       containers:
-        - name: jellyseerr
-          image: seerr/seerr:v3.2.0
+        - name: seerr
+          # image: seerr/seerr:v3.2.0
+          image: seerr/seerr:sha-dfde4d3
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -42,7 +43,7 @@ spec:
               protocol: TCP
           envFrom:
             - configMapRef:
-                name: jellyseerr-env
+                name: seerr-env
           volumeMounts:
             - name: config
               mountPath: /app/config
@@ -54,7 +55,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: jellyseerr-env
+  name: seerr-env
   namespace: yarr
 data:
   TZ: ${yarr_timezone}
@@ -62,7 +63,7 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: yarr-jellyseerr
+  name: yarr-seerr
   namespace: yarr
 spec:
   ports:
@@ -70,5 +71,5 @@ spec:
       port: 5055
       targetPort: http
   selector:
-    app: jellyseerr
+    app: seerr
   type: ClusterIP


### PR DESCRIPTION
This pull request renames the Jellyseerr deployment to Seerr in the Kubernetes configuration, updating all relevant references in the deployment, config map, and service definitions. The changes ensure consistent naming and update the container image to a specific Seerr image.

**Renaming and configuration updates:**

* Renamed the deployment, service, and associated labels from `jellyseerr` to `seerr` in `seerr.yaml` (previously `jellyseerr.yaml`).
* Updated the config map name from `jellyseerr-env` to `seerr-env` and changed all references accordingly. [[1]](diffhunk://#diff-c978cde9153939714000dd2a3726e52c0fdc80f258e0d571b3e74c1130369d1eL57-R74) [[2]](diffhunk://#diff-c978cde9153939714000dd2a3726e52c0fdc80f258e0d571b3e74c1130369d1eL45-R46)

**Container image update:**

* Changed the container image from `seerr/seerr:v3.2.0` to `seerr/seerr:sha-dfde4d3` for the deployment.