### PR TITLE
chore: update qbitorrent to 5.2.0

### DIFF
--- a/kubernetes/apps/k8s00/yarr/qbittorrent.yaml
+++ b/kubernetes/apps/k8s00/yarr/qbittorrent.yaml
@@ -75,7 +75,7 @@ spec:
             echo "ping successfull, exiting"
       containers:
         - name: qbittorrent
-          image: lscr.io/linuxserver/qbittorrent:5.1.4-r3-ls450
+          image: lscr.io/linuxserver/qbittorrent:5.2.0_v2.0.12-ls454
           imagePullPolicy: Always
           securityContext:
             capabilities:

--- a/kubernetes/apps/k8s00/yarr/qbittorrent.yaml
+++ b/kubernetes/apps/k8s00/yarr/qbittorrent.yaml
@@ -72,7 +72,7 @@ spec:
               echo "Ping failed, retrying in 5"
               sleep 5
             done
-            echo "ping successfull, exiting"
+            echo "ping successful, exiting"
       containers:
         - name: qbittorrent
           image: lscr.io/linuxserver/qbittorrent:5.2.0_v2.0.12-ls454


### PR DESCRIPTION
This pull request updates the `qbittorrent` container image to a newer version in the Kubernetes deployment configuration.

Container image update:

* Upgraded the `qbittorrent` container image from `lscr.io/linuxserver/qbittorrent:5.1.4-r3-ls450` to `lscr.io/linuxserver/qbittorrent:5.2.0_v2.0.12-ls454` in `kubernetes/apps/k8s00/yarr/qbittorrent.yaml` to incorporate the latest features and fixes.