### PR TITLE
feat: upgrade prometheus and define grafana persisyency as sts

### DIFF
--- a/kubernetes/infrastructure/k8s00/prometheus.yaml
+++ b/kubernetes/infrastructure/k8s00/prometheus.yaml
@@ -17,7 +17,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: ">= 82.0 < 90.0"
+      version: ">= 85.2.2 < 90.0"
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
@@ -51,6 +51,7 @@ spec:
       #   version: 1
       persistence:
         enabled: true
+        type: sts
         storageClassName: rook-ceph-retain
         accessModes:
           - ReadWriteOnce


### PR DESCRIPTION
This pull request updates the Prometheus deployment configuration in our Kubernetes infrastructure. The main changes are an upgrade to the `kube-prometheus-stack` Helm chart version and an explicit setting for the persistence type.

Helm chart upgrade:

* Upgraded the `kube-prometheus-stack` Helm chart version constraint from `>= 82.0 < 90.0` to `>= 85.2.2 < 90.0` in `prometheus.yaml`, ensuring we use a newer, compatible version.

Persistence configuration:

* Added `type: sts` under the persistence settings in `prometheus.yaml` to explicitly specify the use of StatefulSets for persistent storage.