### PR TITLE
feat: upgrade in-code automatic upgrade

### DIFF
--- a/kubernetes/infrastructure/base/cert-manager.yaml
+++ b/kubernetes/infrastructure/base/cert-manager.yaml
@@ -25,7 +25,7 @@ spec:
   chart:
     spec:
       chart: cert-manager
-      version: ">= v1.20.1 < v1.21.0"
+      version: ">= v1.20.2 < v1.21.0"
       sourceRef:
         kind: HelmRepository
         name: jetstack

--- a/kubernetes/infrastructure/base/ingress-nginx.yaml
+++ b/kubernetes/infrastructure/base/ingress-nginx.yaml
@@ -25,7 +25,7 @@ spec:
   chart:
     spec:
       chart: ingress-nginx
-      version: ">= 4.15.0 < 4.16.0"
+      version: ">= 4.15.1 < 4.16.0"
       sourceRef:
         kind: HelmRepository
         name: ingress-nginx

--- a/kubernetes/infrastructure/k8s00/cilium.yaml
+++ b/kubernetes/infrastructure/k8s00/cilium.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: ">=1.19.3 <1.20.0"
+      version: ">=1.19.4 <1.20.0"
       sourceRef:
         kind: HelmRepository
         name: cilium

--- a/kubernetes/infrastructure/k8s00/cnpg/cloudnative-pg.yaml
+++ b/kubernetes/infrastructure/k8s00/cnpg/cloudnative-pg.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cloudnative-pg
-      version: ">=0.28.0 <0.29.0"
+      version: ">=0.28.2 <0.29.0"
       sourceRef:
         kind: HelmRepository
         name: cnpg

--- a/kubernetes/infrastructure/k8s00/rook-ceph.yaml
+++ b/kubernetes/infrastructure/k8s00/rook-ceph.yaml
@@ -25,7 +25,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph
-      version: ">=1.19.4 <1.20.0"
+      version: ">=1.19.5 <1.20.0"
       sourceRef:
         kind: HelmRepository
         name: rook-ceph
@@ -45,7 +45,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph-cluster
-      version: ">=1.19.4 <1.20.0"
+      version: ">=1.19.5 <1.20.0"
       sourceRef:
         kind: HelmRepository
         name: rook-ceph


### PR DESCRIPTION
This pull request updates several Helm chart version constraints across multiple Kubernetes infrastructure components to use newer patch versions. These updates ensure that the deployed charts include the latest bug fixes and minor improvements while remaining within the same minor version range, reducing the risk of breaking changes.

Helm chart version updates:

* Networking and ingress:
  - Updated `cilium` chart version constraint to ">=1.19.4 <1.20.0" in `k8s00/cilium.yaml`.
  - Updated `ingress-nginx` chart version constraint to ">= 4.15.1 < 4.16.0" in `base/ingress-nginx.yaml`.

* Storage:
  - Updated `rook-ceph` chart version constraint to ">=1.19.5 <1.20.0" in both `rook-ceph.yaml` and `rook-ceph-cluster` sections. [[1]](diffhunk://#diff-ab2440b1257ed70cb85c25fd3ac81628863d7160a88fa38e5cfaa5bf785d2361L28-R28) [[2]](diffhunk://#diff-ab2440b1257ed70cb85c25fd3ac81628863d7160a88fa38e5cfaa5bf785d2361L48-R48)

* Database:
  - Updated `cloudnative-pg` chart version constraint to ">=0.28.2 <0.29.0" in `cnpg/cloudnative-pg.yaml`.

* Security and certificates:
  - Updated `cert-manager` chart version constraint to ">= v1.20.2 < v1.21.0" in `base/cert-manager.yaml`.