### PR TITLE
feat: upgrade yarr stack with seerr helm chart instead of custom depl…

### DIFF
--- a/kubernetes/apps/k8s00/yarr/ingress.yaml
+++ b/kubernetes/apps/k8s00/yarr/ingress.yaml
@@ -59,16 +59,6 @@ spec:
                 name: yarr-bazarr
                 port:
                   number: 6767
-    - host: ${jellyseerr_hostname}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: yarr-jellyseerr
-                port:
-                  number: 5055
   tls:
     - hosts:
         - ${qbittorrent_hostname}
@@ -82,9 +72,6 @@ spec:
     - hosts:
         - ${sonarr_hostname}
       secretName: sonarr-tls
-    - hosts:
-        - ${jellyseerr_hostname}
-      secretName: jellyseerr-tls
     - hosts:
         - ${bazarr_hostname}
       secretName: bazarr-tls

--- a/kubernetes/apps/k8s00/yarr/seerr.yaml
+++ b/kubernetes/apps/k8s00/yarr/seerr.yaml
@@ -1,75 +1,52 @@
-apiVersion: apps/v1
-kind: Deployment
-
-metadata:
-  name: yarr-seerr
-  namespace: yarr
-  labels:
-    app: seerr
-
-spec:
-  replicas: 1
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app: seerr
-  template:
-    metadata:
-      labels:
-        app: seerr
-    spec:
-      securityContext:
-        fsGroup: ${groupId}
-      containers:
-        - name: seerr
-          # image: seerr/seerr:v3.2.0
-          image: seerr/seerr:sha-dfde4d3
-          imagePullPolicy: Always
-          securityContext:
-            capabilities:
-              drop: [ "ALL" ]
-            allowPrivilegeEscalation: false
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-            readOnlyRootFilesystem: false
-            privileged: false
-            runAsUser: ${userId}
-            runAsGroup: ${groupId}
-          ports:
-            - containerPort: 5055
-              name: http
-              protocol: TCP
-          envFrom:
-            - configMapRef:
-                name: seerr-env
-          volumeMounts:
-            - name: config
-              mountPath: /app/config
-      volumes:
-        - name: config
-          persistentVolumeClaim:
-            claimName: yarr-jellyseerr-config
 ---
-apiVersion: v1
-kind: ConfigMap
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
 metadata:
-  name: seerr-env
-  namespace: yarr
-data:
-  TZ: ${yarr_timezone}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: yarr-seerr
+  name: seerr
   namespace: yarr
 spec:
-  ports:
-    - protocol: TCP
-      port: 5055
-      targetPort: http
-  selector:
-    app: seerr
-  type: ClusterIP
+  interval: 1440m
+  url: oci://ghcr.io/seerr-team/seerr/seerr-chart
+  ref:
+    tag: 3.6.0
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: seerr
+  namespace: yarr
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: seerr
+    namespace: yarr
+  values:
+    config:
+      persistence:
+        existingClaim: yarr-jellyseerr-config
+    extraEnv:
+      - name: TZ
+        value: ${yarr_timezone}
+    ingress:
+      enabled: true
+      hosts:
+        - host: ${seerr_hostname}
+      ingressClassName: nginx
+      tls:
+        - hosts:
+            - ${seerr_hostname}
+          secretName: seerr-tls
+    podSecurityContext:
+      fsGroup: ${groupId}
+    securityContext:
+      capabilities:
+        drop: [ "ALL" ]
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+      readOnlyRootFilesystem: false
+      privileged: false
+      runAsUser: ${userId}
+      runAsGroup: ${groupId}

--- a/kubernetes/apps/k8s00/yarr/seerr.yaml
+++ b/kubernetes/apps/k8s00/yarr/seerr.yaml
@@ -29,7 +29,9 @@ spec:
       - name: TZ
         value: ${yarr_timezone}
     ingress:
-      enabled: true
+      enabled: false
+      annotations:
+        cert-manager.io/cluster-issuer: homelab-internal
       hosts:
         - host: ${seerr_hostname}
       ingressClassName: nginx

--- a/kubernetes/clusters/k8s00/yarr.values.sops.yaml
+++ b/kubernetes/clusters/k8s00/yarr.values.sops.yaml
@@ -13,11 +13,10 @@ stringData:
   sonarr_hostname: ENC[AES256_GCM,data:kmGY6XhWx8iqYq5pcAvjIeRJVGOCXPaPUDxdIOPvasK2qQ==,iv:e92dN98ZOupH3la7Rtk00njizgbpcqTDjO6a7qtJVV4=,tag:Yid+8f2k6IebgoajboUC5g==,type:str]
   radarr_hostname: ENC[AES256_GCM,data:Iz0eRT/5Ii1Vu1oysV9hFR6xFgAh5Gfn8gP6SSW1fDOKCQ==,iv:bLUxrg23PngK4BxHHdP1BsiM4rpJGbDQ/WgeDomI4m0=,tag:jHYDIcCossuY1q3QQN78yQ==,type:str]
   bazarr_hostname: ENC[AES256_GCM,data:799x2/62nUa2A7G47yH/GVPbtmKuQjZ7RLLwMHaQg2zrIQ==,iv:thFZPyKkGQhvaw20MeDW+piWepaJLEC48fPHUSEDLCc=,tag:l+y9s10129mN5o9Mwqj90Q==,type:str]
-  jellyseerr_hostname: ENC[AES256_GCM,data:PUU3r2RXsKqPgYYLIKkIKf8Y9CK/L/0mLedIZIUKSs4XpHeGwKc=,iv:g/a7muppZ6ft0B0oVbmNu/Ehtka+YN5VsnMs9VbvTiQ=,tag:yTHixyG48c/75wrbl+1PtA==,type:str]
+  seerr_hostname: ENC[AES256_GCM,data:zUhQHEi9qQOrJWJN1CNqRFt0tRKlA6d2DK7kR7N/2l1jIVelcZQ=,iv:qVA25fzdV4EYlWNf/RxTuzxt/d6DbT8gVCahvwba8FU=,tag:N6FqA6TvPWHPz7ID2fxbEQ==,type:str]
 sops:
   age:
-    - recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
         YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRRmVHOEIvcFUydkZXOUFE
         QmJDM2U5WTNRZHZwQXVsbFluS2pJYzFUVG5jCnpGK05iUi9WUll4R1Y2V3lkUldU
@@ -25,7 +24,8 @@ sops:
         bVVOczFSNlR2T0NRQkdSSlRFQ3FqekUKQmfiuqBl2ycqnoVK7EzuJwB4tG+bmheZ
         TXnD8ftuN0dAGJu9FLY1V5bohGBX0TFGAyzB+RAvzi7EVbB7qiFF9A==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2025-08-30T13:19:41Z"
-  mac: ENC[AES256_GCM,data:m3VTVSpp1vOw19+IfQb7Y7VkUiCUm0R05RFoXQgjQcs3PzlC+PXfl+OIhJxjVravDO/MvQJ6Kvyba4oiHvFmB96uBeLL345tHtLC3For4ePioGGFmQVtomsEdluPV3IJKC6oUOMehvUPGjSt+XOI4yPBb5fZTcJCel1gS8UbR+4=,iv:nsV9Vl4A1/6SDXAar9DLscicS4Y0phkvQzJKMfpkkGw=,tag:s6Ep27sEz+e+LewKAmutiw==,type:str]
+      recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  version: 3.10.2
+  lastmodified: "2026-05-23T00:31:58Z"
+  mac: ENC[AES256_GCM,data:7+kTTdsGDhuBvjWVY+KfQvfEVHCluJcPLnvS3H8GzoEOWHiMMDunPC4BWj2fHTxr/2Vig5d62JNIP1ikpR3T+lQIXDRqMZ3L91Fg0wkC1sGqW2iR0onWLBPjENzXb5jNEwpcmxnSfghEGljzzuGM9gdJaAw9oKgkERUWOO9lLmQ=,iv:R9W2hrKiIVo0GZgxrIQKlJzZ7TdQSPULQWxg0LWrLQY=,tag:ulUVRMGXdmI5PnJHRCmWiw==,type:str]
+  version: 3.13.0


### PR DESCRIPTION
This pull request migrates the deployment of the Seerr (formerly Jellyseerr) application in the `yarr` namespace from a custom Kubernetes Deployment and Service to a FluxCD-managed HelmRelease using the official OCI Helm chart. It also updates related ingress and secret configuration to reflect the rename and new deployment method.

**Seerr (Jellyseerr) migration and configuration:**

* Replaces the custom `Deployment`, `Service`, and `ConfigMap` for Seerr (`yarr-seerr`) with a FluxCD `OCIRepository` and `HelmRelease`, using the official Seerr Helm chart and updating configuration to use the new chart's values structure. [[1]](diffhunk://#diff-c978cde9153939714000dd2a3726e52c0fdc80f258e0d571b3e74c1130369d1eL1-L28) [[2]](diffhunk://#diff-c978cde9153939714000dd2a3726e52c0fdc80f258e0d571b3e74c1130369d1eL40-L75)
* Updates persistent volume claim and environment variable configuration for Seerr to match the Helm chart's requirements, and removes the now-unnecessary Kubernetes resources.

**Ingress and TLS configuration updates:**

* Removes the ingress and TLS configuration for `jellyseerr` and adds corresponding configuration for `seerr` in `ingress.yaml`, ensuring traffic is routed to the new service and using the new hostname and TLS secret. [[1]](diffhunk://#diff-4e4cb6cf351a28dbfa85145d835fa9c42fd960f4389949856f3b124bc0bab23fL62-L71) [[2]](diffhunk://#diff-4e4cb6cf351a28dbfa85145d835fa9c42fd960f4389949856f3b124bc0bab23fL85-L87)

**Secrets and hostname updates:**

* Updates the secrets file to replace `jellyseerr_hostname` with `seerr_hostname`, ensuring that all references use the new application name and encrypted value.…oyment