### PR TITLE
feat: upgrade kavita to 0.9.0.2

### DIFF
--- a/kubernetes/apps/k8s00/manga/kavita.yaml
+++ b/kubernetes/apps/k8s00/manga/kavita.yaml
@@ -17,7 +17,7 @@ spec:
       interval: 1m
   values:
     image:
-      tag: 0.9.0
+      tag: 0.9.0.2
     podSecurityContext:
       fsGroup: ${groupId}
     securityContext:


### PR DESCRIPTION
This pull request makes a minor update to the Kavita application deployment configuration by updating the Docker image tag to a newer patch version.

- Updated the `image.tag` value for the Kavita deployment in `kubernetes/apps/k8s00/manga/kavita.yaml` from `0.9.0` to `0.9.0.2` to use the latest patch release.