### PR TITLE
feat: upgrade pgadmin to 9.15

### DIFF
--- a/kubernetes/apps/k8s00/admin-tools/pgadmin.yaml
+++ b/kubernetes/apps/k8s00/admin-tools/pgadmin.yaml
@@ -100,7 +100,7 @@ spec:
         fsGroup: 5050
       containers:
         - name: pgadmin
-          image: dpage/pgadmin4:9.14
+          image: dpage/pgadmin4:9.15
           imagePullPolicy: Always
           env:
             - name: PGADMIN_DEFAULT_EMAIL


### PR DESCRIPTION
This pull request updates the `pgadmin` container image to the latest patch version in the `pgadmin.yaml` deployment file.

- Dependency update:
  * Upgraded the `pgadmin` container image from version `9.14` to `9.15` in `kubernetes/apps/k8s00/admin-tools/pgadmin.yaml` to ensure the deployment uses the latest features and security fixes.