### PR TITLE
chore: k8s00: change kustomization apps path

### DIFF
--- a/kubernetes/clusters/k8s00/apps.yaml
+++ b/kubernetes/clusters/k8s00/apps.yaml
@@ -1,3 +1,19 @@
+# ---
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: apps-base
+#   namespace: flux-system
+# spec:
+#   interval: 1h
+#   retryInterval: 1m
+#   timeout: 5m
+#   sourceRef:
+#     kind: GitRepository
+#     name: flux-system
+#   path: ./kubernetes/apps/base
+#   prune: true
+#   wait: true
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -11,7 +27,7 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./kubernetes/apps
+  path: ./kubernetes/apps/k8s00
   prune: true
   wait: true
   decryption:


### PR DESCRIPTION
This pull request updates the FluxCD Kustomization configuration for the `k8s00` cluster. The main changes involve introducing a new base Kustomization (currently commented out) and adjusting the deployment path for the existing Kustomization to better organize application manifests.

Configuration improvements:

* Added a commented-out `apps-base` Kustomization definition to serve as a template or future base configuration for shared app resources.
* Changed the `path` in the existing Kustomization from `./kubernetes/apps` to `./kubernetes/apps/k8s00` to scope deployments specifically to the `k8s00` cluster.