### PR TITLE
feat: upgrade k8s00 infrastructure

### DIFF
--- a/kubernetes/infrastructure/k8s00/nvidia.yaml
+++ b/kubernetes/infrastructure/k8s00/nvidia.yaml
@@ -23,7 +23,7 @@ spec:
   chart:
     spec:
       chart: gpu-operator
-      version: ">= 26.3.1 < 26.4.0"
+      version: ">= 26.3.2 < 26.4.0"
       sourceRef:
         kind: HelmRepository
         name: nvidia

--- a/kubernetes/infrastructure/k8s00/prometheus.yaml
+++ b/kubernetes/infrastructure/k8s00/prometheus.yaml
@@ -17,7 +17,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: ">= 85.2.2 < 90.0"
+      version: ">= 86.1.0 < 90.0"
       sourceRef:
         kind: HelmRepository
         name: prometheus-community

--- a/kubernetes/infrastructure/k8s00/rook-ceph.yaml
+++ b/kubernetes/infrastructure/k8s00/rook-ceph.yaml
@@ -25,7 +25,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph
-      version: ">=1.19.5 <1.20.0"
+      version: ">=1.19.6 <1.20.0"
       sourceRef:
         kind: HelmRepository
         name: rook-ceph
@@ -45,7 +45,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph-cluster
-      version: ">=1.19.5 <1.20.0"
+      version: ">=1.19.6 <1.20.0"
       sourceRef:
         kind: HelmRepository
         name: rook-ceph

--- a/kubernetes/starter/k8s00/bootstrap/cilium/kustomization.yaml
+++ b/kubernetes/starter/k8s00/bootstrap/cilium/kustomization.yaml
@@ -5,7 +5,7 @@ helmCharts:
     repo: https://helm.cilium.io/
     releaseName: cilium
     namespace: kube-system
-    version: 1.19.3
+    version: 1.19.4
     valuesInline:
       ipam:
         mode: kubernetes


### PR DESCRIPTION
This pull request updates Helm chart versions for several core Kubernetes infrastructure components to incorporate the latest patch releases. These changes ensure that the cluster benefits from recent bug fixes and minor improvements while staying within the current major/minor version constraints.

**Helm chart version updates:**

* **Cilium networking:** Upgraded the `cilium` Helm chart version from `1.19.3` to `1.19.4` in `kubernetes/starter/k8s00/bootstrap/cilium/kustomization.yaml` to include the latest fixes.
* **NVIDIA GPU Operator:** Updated the `gpu-operator` chart version constraint to `>= 26.3.2 < 26.4.0` in `kubernetes/infrastructure/k8s00/nvidia.yaml` for improved compatibility and bug fixes.
* **Prometheus monitoring:** Increased the minimum version of the `kube-prometheus-stack` chart to `86.1.0` in `kubernetes/infrastructure/k8s00/prometheus.yaml` to stay current with patch updates.
* **Rook Ceph storage:** Bumped both `rook-ceph` and `rook-ceph-cluster` chart version constraints to `>=1.19.6 <1.20.0` in `kubernetes/infrastructure/k8s00/rook-ceph.yaml` to capture the latest stable release. [[1]](diffhunk://#diff-ab2440b1257ed70cb85c25fd3ac81628863d7160a88fa38e5cfaa5bf785d2361L28-R28) [[2]](diffhunk://#diff-ab2440b1257ed70cb85c25fd3ac81628863d7160a88fa38e5cfaa5bf785d2361L48-R48)