### PR TITLE
chore: rook-ceph change api version from v2beta1 to v2

### DIFF
--- a/kubernetes/infrastructure/k8s00/rook-ceph.yaml
+++ b/kubernetes/infrastructure/k8s00/rook-ceph.yaml
@@ -13,7 +13,7 @@ spec:
   interval: 1440m
   url: https://charts.rook.io/release
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: rook-ceph-operator
@@ -35,7 +35,7 @@ spec:
     monitoring:
       enabled: true
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: rook-ceph-cluster


### PR DESCRIPTION
This pull request updates the API version used for `HelmRelease` resources in the `rook-ceph.yaml` file to ensure compatibility with newer versions of FluxCD.

HelmRelease API version updates:

* Updated the `apiVersion` for both the `rook-ceph-operator` and `rook-ceph-cluster` `HelmRelease` resources from `helm.toolkit.fluxcd.io/v2beta1` to `helm.toolkit.fluxcd.io/v2` to align with the latest stable FluxCD API. [[1]](diffhunk://#diff-ab2440b1257ed70cb85c25fd3ac81628863d7160a88fa38e5cfaa5bf785d2361L16-R16) [[2]](diffhunk://#diff-ab2440b1257ed70cb85c25fd3ac81628863d7160a88fa38e5cfaa5bf785d2361L38-R38)