### PR TITLE
feat: bootstrap cluster: add ca endpoints

### DIFF
--- a/kubernetes/apps/bootstrap/ca/http-route.yaml
+++ b/kubernetes/apps/bootstrap/ca/http-route.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ca-mgmt-https
+  namespace: smallstep
+spec:
+  parentRefs:
+    - name: ca-mgmt
+      namespace: smallstep
+      sectionName: https
+      port: 443
+  hostnames:
+    - "ca.${mgmtDomainOld}"
+  rules:
+    - name: https
+      backendRefs:
+        - name: https
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ca-mgmt-http
+  namespace: smallstep
+spec:
+  parentRefs:
+    - name: ca-mgmt
+      namespace: smallstep
+      sectionName: http
+      port: 80
+  hostnames:
+    - "ca.${mgmtDomainOld}"
+  rules:
+    - name: http
+      backendRefs:
+        - name: http
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ca-service-https
+  namespace: smallstep
+spec:
+  parentRefs:
+    - name: ca-service
+      namespace: smallstep
+      sectionName: https
+      port: 443
+  hostnames:
+    - "ca.${serviceDomainOld}"
+  rules:
+    - name: https
+      backendRefs:
+        - name: https
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ca-service-http
+  namespace: smallstep
+spec:
+  parentRefs:
+    - name: ca-service
+      namespace: smallstep
+      sectionName: http
+      port: 80
+  hostnames:
+    - "ca.${serviceDomainOld}"
+  rules:
+    - name: http
+      backendRefs:
+        - name: http
+          port: 443

--- a/kubernetes/apps/bootstrap/ca/http-route.yaml
+++ b/kubernetes/apps/bootstrap/ca/http-route.yaml
@@ -34,7 +34,7 @@ spec:
   rules:
     - name: http
       backendRefs:
-        - name: http
+        - name: https
           port: 443
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -72,5 +72,5 @@ spec:
   rules:
     - name: http
       backendRefs:
-        - name: http
+        - name: https
           port: 443

--- a/kubernetes/apps/bootstrap/gateway.yaml
+++ b/kubernetes/apps/bootstrap/gateway.yaml
@@ -100,7 +100,7 @@ spec:
     - name: http
       port: 80
       protocol: HTTP
-      hostname: "*.${mgmtDomainOld}"
+      hostname: "*.${serviceDomainOld}"
     - name: https
       protocol: HTTPS
       port: 443

--- a/kubernetes/apps/bootstrap/gateway.yaml
+++ b/kubernetes/apps/bootstrap/gateway.yaml
@@ -26,7 +26,7 @@ spec:
       tls:
         mode: Terminate
         certificateRefs:
-          - name: bootstrap-shared-wildcard
+          - name: bootstrap-shared-mgmt-wildcard
     # - name: http-unifi
     #   port: 8080
     #   protocol: HTTP
@@ -35,6 +35,34 @@ spec:
     #   port: 8443
     #   protocol: HTTPS
     #   hostname: "*.${mgmtDomainOld}"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ca-mgmt
+  namespace: smallstep
+  annotations:
+    cert-manager.io/cluster-issuer: homelab-internal
+spec:
+  infrastructure:
+    annotations:
+      lbipam.cilium.io/ips: "${caMgmtIpv4},${caMgmtIpv6}"
+    labels:
+      network: mgmt
+  gatewayClassName: internal
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      hostname: "*.${mgmtDomainOld}"
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.${mgmtDomainOld}"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: ca-mgmt-wildcard
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -53,6 +81,30 @@ spec:
     - name: http
       port: 80
       protocol: HTTP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ca-service
+  namespace: smallstep
+  annotations:
+    cert-manager.io/cluster-issuer: homelab-internal
+spec:
+  infrastructure:
+    annotations:
+      lbipam.cilium.io/ips: "${caServiceIpv4},${caServiceIpv6}"
+    labels:
+      network: service
+  gatewayClassName: internal
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.${serviceDomainOld}"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: ca-service-wildcard
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway

--- a/kubernetes/apps/bootstrap/gateway.yaml
+++ b/kubernetes/apps/bootstrap/gateway.yaml
@@ -97,6 +97,10 @@ spec:
       network: service
   gatewayClassName: internal
   listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      hostname: "*.${mgmtDomainOld}"
     - name: https
       protocol: HTTPS
       port: 443

--- a/kubernetes/apps/bootstrap/netbootxyz/http-route.yaml
+++ b/kubernetes/apps/bootstrap/netbootxyz/http-route.yaml
@@ -11,7 +11,7 @@ spec:
       sectionName: https
       port: 443
   hostnames:
-    - "netbootxyzmgmt.bootstrap.mgmt.${homeDomainOld}"
+    - "netbootxyzmgmt.bootstrap.${mgmtDomainOld}"
   rules:
     - name: https
       backendRefs:
@@ -30,7 +30,7 @@ spec:
       sectionName: http
       port: 80
   hostnames:
-    - "netbootxyz.bootstrap.mgmt.${homeDomainOld}"
+    - "netbootxyz.bootstrap.${mgmtDomainOld}"
   rules:
     - name: https
       backendRefs:
@@ -49,7 +49,7 @@ spec:
       sectionName: http
       port: 80
   hostnames:
-    - "netbootxyz.bootstrap.service.${homeDomainOld}"
+    - "netbootxyz.bootstrap.${serviceDomainOld}"
   rules:
     - name: https
       backendRefs:
@@ -68,7 +68,7 @@ spec:
       sectionName: http
       port: 80
   hostnames:
-    - "netbootxyz.bootstrap.k8s00.${homeDomainOld}"
+    - "netbootxyz.bootstrap.${k8s00DomainOld}"
   rules:
     - name: https
       backendRefs:

--- a/kubernetes/clusters/bootstrap/global.values.sops.yaml
+++ b/kubernetes/clusters/bootstrap/global.values.sops.yaml
@@ -11,6 +11,8 @@ stringData:
   mgmtDomain: ENC[AES256_GCM,data:/T4aHE6ZzbSpwg0ywkn8PkY=,iv:7SHcxSNNx0obpWvbkv0oomKDHmr3x5r50/3wiEqNxv8=,tag:KU8z0TSWkP17peZzQlbFvw==,type:str]
   serviceDomain: ENC[AES256_GCM,data:uYCbJB3Jg2bOo/tMlfrra6hIKVU6,iv:dYsQ1d4UCfzKwdlwwIi3+zXsEInV7ekqvCrXHpv1Xks=,tag:NyGATP6iJHQvIJgk9NFk1w==,type:str]
   serviceDomainOld: ENC[AES256_GCM,data:Xss4H3PV11WmdNR6JKQmvfrp+78=,iv:S7kVmMrOR1ghSQJ8ojmpYouWd4mPHNMX0DFDzn3hi9k=,tag:L3IgbmtZsXumW5vySl2KnQ==,type:str]
+  k8s00Domain: ENC[AES256_GCM,data:InemhERBLt7yvakwDW2UIoa1nA==,iv:TJKzg1u4gFxev1+eALLd7wMFJbjPmSwXuRRuNj5OpLM=,tag:GMRwFa+2+m23DhRMCpRQRA==,type:str]
+  k8s00DomainOld: ENC[AES256_GCM,data:6yaWK0lbbDBDcqMN8SKdqcjO,iv:a+2ovva3CWVyc4BbzEa7+fRhIdIuZyvAbgLiBk2X8Cg=,tag:zng00dqrtUhErNvqscj3lg==,type:str]
   homeTimezone: ENC[AES256_GCM,data:1wAxcKsW9w==,iv:WUfwWfWR38PbL2b2/rHrq9Fn9B7IW/JQac2P5bNmX/Y=,tag:YHuETaVAxj6xgNTT4yaOSQ==,type:str]
   bootstrapMgmtIpv4: ENC[AES256_GCM,data:7lalLZ1TkGBR7NU=,iv:mItSXdbOqnFhqV4gLMQ5/yXoMsMnbrAPMWhWaesEKHA=,tag:rypBEA8AxCeIbTCEFAeY7g==,type:str]
   bootstrapMgmtIpv6: ENC[AES256_GCM,data:RNhhSmBfdBgKAvNoyf97Dz8f/KayCw==,iv:L00CnwWrzNfKAeXEbmNINcnFUd9xUYYkKuIuU4bvVnI=,tag:2+MKTg+rWkJljAIpjdaqiA==,type:str]
@@ -18,6 +20,10 @@ stringData:
   bootstrapServiceIpv6: ENC[AES256_GCM,data:hBRdq3Fm1+Zm/FWexQEMW9dUR3E/Xw==,iv:y8wDuqV0cH5QgNTOWxSXS1rwlstH4uOKf62pPIZZYfE=,tag:A/ZVKmgGT9gMUmviyr8ArA==,type:str]
   bootstrapK8s00Ipv4: ENC[AES256_GCM,data:hkxwMwQL5LLuitsx,iv:wbsh4YkozU5HaaDrwyBUkwZ2EWMj+hBVuVpu9ZcA/Ww=,tag:jdeNNB7PA2zehfh+/m6lcw==,type:str]
   bootstrapK8s00Ipv6: ENC[AES256_GCM,data:fB8AjP88oAPOcyPDxiVl82fgnM+yFw==,iv:FyEsSHVdIrS1u2xMfloxKemxLQiIb35Lv68tpdcXklk=,tag:SRj0lrWUB8xMg7xAMEylQw==,type:str]
+  caMgmtIpv4: ENC[AES256_GCM,data:+Yvk/RGVXWDM4GWS,iv:EEzxOGiJY0nsfLL5RgheV1P8x4knxvOF113Qjaz6P/M=,tag:xBIFInAN5tLZZn0WHqlJOA==,type:str]
+  caMgmtIpv6: ENC[AES256_GCM,data:zLTtaBmpnVC5PyN6i9S38zUEmSv5QGA=,iv:0vEmH1PV6zZFPaDtQ5VHJtGSvL5/qo7FmyPSIDDsRgQ=,tag:uumpgZ6Dxv+0dRpa0wb6QA==,type:str]
+  caServiceIpv4: ENC[AES256_GCM,data:Nxebg/k0lUZNDXQTLw==,iv:WcG81uUhQZmSFTBH4zfN+9dHZP3pmMR1we8oC2diLJ0=,tag:pVXWO3bsLKVZqjqOwH5tZQ==,type:str]
+  caServiceIpv6: ENC[AES256_GCM,data:v8sBWHbA2oeiYH+VuGmsyIXPSTf6QuM=,iv:8uY/dljhJBFXqMpLCFNgGDlAfNaFrboSiXnsk1hy3Ww=,tag:261oDenmheScHsIGXNXtzA==,type:str]
 sops:
   age:
     - enc: |
@@ -30,6 +36,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-05-29T19:42:17Z"
-  mac: ENC[AES256_GCM,data:+LuYzXNqFnNC6xorfBgYz5HUegl1888jqUgA84kZmcHBAWarMYNItUN5vh+K2XYTCeOHp+kXURtLFkFm7sEAucbyL0qMKZ/TA+152m8/kcdJ0UnM5wLZdkb6Ff1E/vO1UwJ00b/jsK1HaCebVYu/oFhRcZYka5MjvnJhwRAPH/s=,iv:O2PGhukcSEzMUXW8LSTW5C9+z4do+GGoftfSeP/LhP0=,tag:gKKWcvGDtKrIXY1D2ON8PA==,type:str]
+  lastmodified: "2026-05-31T21:08:55Z"
+  mac: ENC[AES256_GCM,data:3ojCb0RBntUdqB2GAiYwBGS4j0dJtJH4tImUAYwnWo5qheAKlkCzozId/UFinaOApDuzyp9GfF3rkj+x/ZRVLQ2USro34nO/SvXCQuYdazRxnM09XUT8gVdmOa1d5umqRr4cblqzmI2yfJfaEn3K3H4gY+L+XA3amEb4eWqqaaY=,iv:CJ1kobTLwkAQgCYhDueS1ceElE+Q7wrKPeTY5qCKtEQ=,tag:Np0XeuolQii338PICwOu6w==,type:str]
   version: 3.13.1

--- a/kubernetes/infrastructure/bootstrap/issuers.yaml
+++ b/kubernetes/infrastructure/bootstrap/issuers.yaml
@@ -23,5 +23,9 @@ spec:
             parentRefs:
               - name: bootstrap-shared-mgmt
                 namespace: bootstrap
+              - name: ca-mgmt
+                namespace: smallstep
+              - name: ca-service
+                namespace: smallstep
               # - name: pihole-shared
               #   namespace: pihole


### PR DESCRIPTION
This pull request introduces new Certificate Authority (CA) management and service gateways to the Kubernetes bootstrap environment, updates HTTPRoute and domain references for improved routing, and adds new IP/domain secrets required for these changes. The most important changes are grouped below:

**1. Introduction of CA Gateways and Routing:**

* Added two new `Gateway` resources (`ca-mgmt` and `ca-service`) in the `smallstep` namespace, each with dedicated HTTP and HTTPS listeners, IP annotations, and certificate references for CA management and service traffic. (`kubernetes/apps/bootstrap/gateway.yaml`) [[1]](diffhunk://#diff-99185a1fa652678b8b7d23ff89d69983c839b5cf31e96c0c315f6840ac454efdR41-R68) [[2]](diffhunk://#diff-99185a1fa652678b8b7d23ff89d69983c839b5cf31e96c0c315f6840ac454efdR87-R114)
* Created corresponding `HTTPRoute` resources for both management and service CA endpoints, routing traffic based on hostnames and ports. (`kubernetes/apps/bootstrap/ca/http-route.yaml`)

**2. Updates to Certificate Issuer Routing:**

* Updated the list of parentRefs for the HTTP issuer to include the new CA gateways in addition to the existing ones, ensuring certificates can be issued for the new endpoints. (`kubernetes/infrastructure/bootstrap/issuers.yaml`)

**3. Domain and Hostname Standardization:**

* Standardized and updated domain variables and hostnames in multiple HTTPRoute resources for `netbootxyz` to use the new `mgmtDomainOld`, `serviceDomainOld`, and `k8s00DomainOld` variables, replacing the previous `homeDomainOld` references. (`kubernetes/apps/bootstrap/netbootxyz/http-route.yaml`) [[1]](diffhunk://#diff-6e154f3d7176768a69423ee70161bb5d8f5c2a2faed039cbed28b0e60a1da291L14-R14) [[2]](diffhunk://#diff-6e154f3d7176768a69423ee70161bb5d8f5c2a2faed039cbed28b0e60a1da291L33-R33) [[3]](diffhunk://#diff-6e154f3d7176768a69423ee70161bb5d8f5c2a2faed039cbed28b0e60a1da291L52-R52) [[4]](diffhunk://#diff-6e154f3d7176768a69423ee70161bb5d8f5c2a2faed039cbed28b0e60a1da291L71-R71)

**4. Secret and Value Additions:**

* Added new encrypted secrets for CA management and service IP addresses and domains (`caMgmtIpv4`, `caMgmtIpv6`, `caServiceIpv4`, `caServiceIpv6`, `k8s00Domain`, `k8s00DomainOld`) to support the new CA gateways and routing. (`kubernetes/clusters/bootstrap/global.values.sops.yaml`)

**5. Certificate Reference Update:**

* Changed the certificate reference for the bootstrap shared management gateway to use `bootstrap-shared-mgmt-wildcard` for improved certificate management. (`kubernetes/apps/bootstrap/gateway.yaml`)