### PR TITLE
chore: k8s00: yarr: gateway: fix misspelled variable

### DIFF
--- a/kubernetes/apps/k8s00/yarr/gateway.yaml
+++ b/kubernetes/apps/k8s00/yarr/gateway.yaml
@@ -20,7 +20,7 @@ spec:
         mode: Terminate
         certificateRefs:
           - kind: Secret
-            name: yarr-wildcart-cert
+            name: yarr-wildcard-cert
       allowedRoutes:
         namespaces:
           from: Same


### PR DESCRIPTION
This pull request includes a minor fix to the `kubernetes/apps/k8s00/yarr/gateway.yaml` file, correcting a typo in the certificate secret name from `yarr-wildcart-cert` to `yarr-wildcard-cert`.

* Fixed the secret name for the certificate reference from `yarr-wildcart-cert` to `yarr-wildcard-cert` in `gateway.yaml` to ensure the correct secret is used.