### PR TITLE
feat: remove generic-device-plugin podmonitor

### DIFF
--- a/kubernetes/infrastructure/base/generic-device-plugin/kustomization.yaml
+++ b/kubernetes/infrastructure/base/generic-device-plugin/kustomization.yaml
@@ -3,4 +3,3 @@ kind: Kustomization
 resources:
   # generic-device-plugin
   - https://raw.githubusercontent.com/squat/generic-device-plugin/main/manifests/generic-device-plugin.yaml
-  - https://raw.githubusercontent.com/squat/generic-device-plugin/main/manifests/podmonitor.yaml


### PR DESCRIPTION
This pull request makes a small change to the `kustomization.yaml` file for the generic device plugin by removing the `podmonitor.yaml` resource. This means the PodMonitor resource will no longer be deployed as part of this kustomization.