### PR TITLE
fix: set gitrepository's correct name

### DIFF
--- a/kubernetes/clusters/bootstrap00/apps.yaml
+++ b/kubernetes/clusters/bootstrap00/apps.yaml
@@ -10,7 +10,7 @@
 #   timeout: 5m
 #   sourceRef:
 #     kind: GitRepository
-#     name: flux-system
+#     name: homelab
 #   path: ./kubernetes/apps/base
 #   prune: true
 #   wait: true
@@ -26,7 +26,7 @@ spec:
   timeout: 5m
   sourceRef:
     kind: GitRepository
-    name: flux-system
+    name: homelab
   path: ./kubernetes/apps/bootstrap00
   prune: true
   wait: true

--- a/kubernetes/clusters/bootstrap00/infrastructure.yaml
+++ b/kubernetes/clusters/bootstrap00/infrastructure.yaml
@@ -10,7 +10,7 @@ spec:
   timeout: 5m
   sourceRef:
     kind: GitRepository
-    name: flux-system
+    name: homelab
   path: ./kubernetes/infrastructure/base
   prune: true
   wait: true
@@ -55,7 +55,7 @@ spec:
   timeout: 5m
   sourceRef:
     kind: GitRepository
-    name: flux-system
+    name: homelab
   path: ./kubernetes/infrastructure/bootstrap00
   prune: true
   wait: true


### PR DESCRIPTION
This pull request updates the source Git repository name used by Flux in the Kubernetes cluster configuration files. The changes ensure that the cluster resources reference the correct repository, `homelab`, instead of the previous default, `flux-system`.

Repository reference updates:

* Updated the `sourceRef.name` from `flux-system` to `homelab` in both the `apps.yaml` and `infrastructure.yaml` files for the `bootstrap00` cluster, ensuring that Flux pulls resources from the intended repository. [[1]](diffhunk://#diff-01714416717c9fe27825ad0b6d31fec1514428ef29463b888467c0fff80417f5L29-R29) [[2]](diffhunk://#diff-47a823254ea8b5c72d2364cdefa8e556c6cf390cf8e6925cea90abd930c23670L13-R13) [[3]](diffhunk://#diff-47a823254ea8b5c72d2364cdefa8e556c6cf390cf8e6925cea90abd930c23670L58-R58)
* Made a similar update in a commented-out section of `apps.yaml` to maintain consistency in documentation and potential future configuration.