### PR TITLE
fix: change variable names to compatible ones

### DIFF
--- a/kubernetes/clusters/bootstrap00/step-ca.values.sops.yaml
+++ b/kubernetes/clusters/bootstrap00/step-ca.values.sops.yaml
@@ -4,12 +4,12 @@ metadata:
   name: step-ca-values
   namespace: flux-system
 stringData:
-  step-ca_password: ENC[AES256_GCM,data:rf13ExVPrian6P3FZqH1Kjhr8txTJtM4P+dTX28+HR8SPr8vl0iqzru66Evrp38zpXgNG/r9jeyFfRrzPXc41OJpx3yKTkDiVXAn43pAzcxlJUo73u6oBg==,iv:f88/e1fy4KKie6SuTuE2gwwx+PY+jyJ7BDAWCHqMOMk=,tag:P1bdcDWi5zwwq7iPyKBytg==,type:str]
-  step-ca_kid: ENC[AES256_GCM,data:jR6iTf5xSHhz4pma5y53YKr+mhZox17dn2kLXlelfPo3aMi8oA25BoF0aw==,iv:6oUIt3pR39xijYbqbxtVXZHECnZiErcxZ6vdMZZbYnY=,tag:ETKzH/kIqJaOjRqxPh+1kA==,type:str]
-  step-ca_x: ENC[AES256_GCM,data:AgnS7u7l1P2nhQu+zLrEEV+KiAQt+xyQzGKetUE9fHGfrDtGRNc7ulFIGA==,iv:zpy6lwUizMDcAwAO4D+xJqNX9lTYDtN+pBlae9jwdx8=,tag:7OCo1QD5qLiVX4+zcS9/Aw==,type:str]
-  step-ca_y: ENC[AES256_GCM,data:d+LoUPSg6TpEXRGOPlNsKAoKc1sIsVzKDywK3/re6bfgmMN7n4X8BtB25w==,iv:xVycfTTdrSRIy4PYIXh4VQHQtlgb5e+aG0Y0Uxphk80=,tag:x57UkS/jJdXqXiuvo1Xrvg==,type:str]
-  step-ca_intermediate_ca_key: ENC[AES256_GCM,data:P7/UCXj3XFkLgjNrUIbAU1d2JjM8uDPcbdoMcnzCgQdVGFiBT2mPvI7wy5pYM/ZnEfJ9U9kpiViZJIxgTqzu4AGaR/9vn7Zhwfo7DtoW+d/WtenQOnilbkvChfTbTcdGDlu7O8iU76paa8qnRgPijBnHXSZDF4xwgtU8JljXUrrzJik2pa5gCUoe6M72shRQp7aogx9KFBEeaExVS/P3j1bgZikM1h2EubaTzr3h30OSvOfHVS8+vJuoYWv7mq7lKBgHNwZiAhBcvsE2jNPewCRPcB8U3BnH6PAfx6savlvVCDQf5y+CJcw7pDV6mmgcYpd4N8yzpyZZbF+JwJNSh+G9f0bEX5IFjyY91iOHpQfAqgqI70texP+BV+yKMZz+hZLFG2Wui1vIqz0rnzacN+Mq8Y4JvjqzqyI=,iv:7nR8qonyJUD4H8AeYjCtYyshKDfAm+2NnAcPg9jVaoc=,tag:aL8mtMBCObxpbMPcE3n3CA==,type:str]
-  step-ca_root_ca_key: ENC[AES256_GCM,data:FlHOrpW/CzJ0dVPEolw/Cl9ULy1Gn+urw6zPuUhSct7ujPoSOWKS6bZZdl5msPvs2ZYHfV+YYcIj3r3WQSUDmLH+SZ4Htf7a39VtUWI1VMb2/ExaCRPUr1vAPZd3BUzlD5I2q/VA6Mdaa96k+RKn+PDr8r5XTr/2w+vS0OpqFS2KjnEGrKYSR2kET1wY8sxgVpfza92g7afMCXbXAB73cTImXuZw7SPcfbSeKla2PWoEIDWjjLOFJN6ZQoKhwcJXl1Xlnpn4sDSFJvPJcoSytIvVUCUiONn5jePaw76GbhBmBC7kT4Qje4XgcgqXoxMGKZNpyu/875QsgT5J7y2k0BBUiXlW1DVo3Q00hWNlwT4CWSnOnZj3DnjdMvMDac8CzsrMFOy4uSnOCAQqBjCegTTSVX6xv5mCJOE=,iv:77pcPysEEBvM8u59YzFkX9eT3QA324bFR/Z6rRTmf+Q=,tag:f2Yi4IacFVOHSWXGuJlvgQ==,type:str]
+  stepCa_password: ENC[AES256_GCM,data:9Epe/GSX7eg0Y+zay7vVv9m1nFzxVr2U3kkWl/i7j72fPg6Mp2Sp0Eoe9l1Ju89KzvivYsuIQctcj44qCWT/FUv/jRWVL+xknbFZTthG145y9+/uD2N3ZA==,iv:QBBgy6DuHbtAUvyzHs/ITGlflYVjUopnVfV/VTjpCi4=,tag:jsUDMTEOMSoLahbDIQEa2A==,type:str]
+  stepCa_kid: ENC[AES256_GCM,data:HRKtZHTwbz3dXstMmdg5+Skwj/Tz7mpKRhv8jahmD2JgKKrF8xrZY23Fvw==,iv:In7kG1euACV3UsK+/f3BasDOrD4+3IA5UcLZm4BaKxM=,tag:HynFFkydJ9Shqfjzt9GbGQ==,type:str]
+  stepCa_x: ENC[AES256_GCM,data:shZRMK+dk/Dg1kCcD59kzcVvUK1lpKK412TQUT0Y3HvfEOuAr33QO3nrrw==,iv:e4HmHC8ZR1LEcf614UAh4VF3RXkfapf74BYOuJr2vvs=,tag:AMX42CHp0LvOTD3zmfAKtA==,type:str]
+  stepCa_y: ENC[AES256_GCM,data:vzZE7cqSvgN1DJY+/pwmFnwEWGsOX8/frguubd8x/8+QYGiP+4c7Y3bhDQ==,iv:zTCuKmfvGQbyrG+4O5ULBB5E7xsvR9jvm+nWdViyT6c=,tag:v4D5YaOiGMYxmYBbOkyAtw==,type:str]
+  stepCa_intermediate_ca_key: ENC[AES256_GCM,data:TQj/TyCvA6v+HvMiAYOMzRZT0vsA77ekHXzbN3m28nvFYOuZ9wQUVpLoB2PXm1p48hG0P9WcOmOQnfkKDj4TAsMiBDj7NnbAajvcFZZZ7PSvo5w/Weg/nxSQ17B8U3s2n0DYFhy699ExfcwJESprPeg7+JCm89nhpGCSm4b78dSXOUkBTsn6wiV13Flvz8zppCChhk1dkdhvmfF81h7PaSxjmLms+BaBGrj6sTcnVyFptyah/gou74jpy/iC8y5DLa7b9o7bpCnmRYIzuqE893WvhbrQHK0++yAzqdP67phtUXdoQVsnYL9nIcLpqzz2fTqs2g0RSZPXGi54dFLLsoPcAMZpVTR9jcMH7jB+4UpLIZywrvmGcoYfTMzJGtiDakiNhUym/L7fZ/yD4TJZa51VekGCLgqE7Mw=,iv:p1javiVVqRvpXmXhrFSYnLuW19roKAuxdTusq4MhgJY=,tag:ih9XmKaO82mZKTQU4HAWZw==,type:str]
+  stepCa_root_ca_key: ENC[AES256_GCM,data:B3IqvYL+T8iPNVY/c8X6r7SHajfef+kJtQkOfslMQR++6wXjh5NrzV+NsYxWXZpkasHk3L1S4SmVcX765a5m8COUxLtEyv5u1dTPdT0ju3uHHdxsTvDplR5HlGECvYzoAC7Vp+PT3uNQa8hrGKXAY3JR3r4R0He/unEjnSq2hRg0eUL6qhuDzH4QkeN2jAYbUjs27xvL4YznuL1XmSNQfh9DBXyqoiCBT6g/mhLD1h2UTckp3mDjhdY11T3m4xB54uq0ddZZ+B6GjJT2tAVIJYJ/vER44b1Cb0UZ0CcquSUy7n4EpUNPxylexI/lyzZEU3ScgHV21SUsQZ0ephaEXXYHUFlybczzMDpxVtl9sLPVWfugvGDe9Iyg1WVE5rHUakTBDXu6UCTzzjILt/yiRf/KJCTg8m0Nho4=,iv:rh1YSK7uCeWMvOV1UstZwtZNokSgkUbVV4FFYGA90lM=,tag:aV/F4uiWz30TsEQwny4lIQ==,type:str]
 sops:
   age:
     - enc: |
@@ -22,6 +22,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-05-31T12:24:05Z"
-  mac: ENC[AES256_GCM,data:eaW+A4PAAk3H1QVF/0gsu4vY2TU/E1DTS2ZbPZt6/xnyYQZGhGas33I3zueJeQ7wmqFkeSj/OLMNptoTbesxXxzSXOerMDXCYUt41h6+XqIXmK+o8+FHzvtsfhvHNasGFYSDPZsWQZqr3niPNVicW/oTQF6EeH9td/PawvNIj40=,iv:m+VhvtgAnv+z76O+MHWMcRbvxcjUMSp38ZVX5IoZSFU=,tag:u2RP6ZqA+36sxJw+S+pDNA==,type:str]
+  lastmodified: "2026-06-06T03:48:28Z"
+  mac: ENC[AES256_GCM,data:OTyILRfT+KheWR+xGEuu9/Qsdh4QG7qUZM7dOOX2Yi9kGHttusGuG393/HXuFxV8NqkJl2648aLzaLDaIQ7E5yeRyly9ZvJbNsf0ZXMWnTj3Rk6pkR7HKy1cZFG/qTH9pj3lKp4OMm/DgIP1isv1wvwgFu2Uecqm5eYJp99VmK4=,iv:OCnCIEeCV/FqYGz8S4+/e2IcggUsmlRnT6tvtat85Tg=,tag:U9gTz5Bwq69kT3DAYpNlVw==,type:str]
   version: 3.13.1

--- a/kubernetes/infrastructure/bootstrap00/smallstep.yaml
+++ b/kubernetes/infrastructure/bootstrap00/smallstep.yaml
@@ -60,7 +60,7 @@ spec:
               claims:
                 maxTLSCertDuration: 720h
               provisioners:
-                - {"type":"JWK","name":"admin@${mainDomain}","key":{"use":"sig","kty":"EC","kid":"${step-ca_kid}","crv":"P-256","alg":"ES256","x":"${step-ca_x}","y":"${step-ca_y}"},"encryptedKey":"eyJhbGciOiJQQkVTMi1IUzI1NitBMTI4S1ciLCJjdHkiOiJqd2sranNvbiIsImVuYyI6IkEyNTZHQ00iLCJwMmMiOjYwMDAwMCwicDJzIjoiemZ0NTBabzJmeWNrZk5TYW1Ibm9qdyJ9.6nym_4zosDnCkFzLjMmBUAPPdVXmQejg2a3XgaRJvfUTD5-j-oXo4w.56Q7GoiOU9X4kOTY.Jz4amXuCkJl7PWghNnvYt4m3KQkpsFvnQsnxIio1K2d49h8FDeXnmkSF3Xq8eMzsJ9kz_Fen7DzO2gR4FBdwItZU_oqaXb3uaozEPoyyVZIOf83KXuozDBjCAcEtCSmDfYMuVZQtDP2n_8WhhYyHOFn8TPY2NR5bZX5JmRdRuzBR1mA8mI1vRabMAhL2fNlXJb9fX6B8Yi9KJ8ezPtDYvS_joPoFU-jyUbpHBgnEIkHUp63QGx3fETUfFN4BabDHGag0It77CUYXpQaln1CktkHxV95aRacQHY68vC3fhA7RkIRVjWG3KLiVrAB3fA5xMIQi8SVJ6VfGAmGkjjc.imF-TXh0f9YudftJ6ZkS8A","options":{"x509":{},"ssh":{}}}
+                - {"type":"JWK","name":"admin@${mainDomain}","key":{"use":"sig","kty":"EC","kid":"${stepCa_kid}","crv":"P-256","alg":"ES256","x":"${stepCa_x}","y":"${stepCa_y}"},"encryptedKey":"eyJhbGciOiJQQkVTMi1IUzI1NitBMTI4S1ciLCJjdHkiOiJqd2sranNvbiIsImVuYyI6IkEyNTZHQ00iLCJwMmMiOjYwMDAwMCwicDJzIjoiemZ0NTBabzJmeWNrZk5TYW1Ibm9qdyJ9.6nym_4zosDnCkFzLjMmBUAPPdVXmQejg2a3XgaRJvfUTD5-j-oXo4w.56Q7GoiOU9X4kOTY.Jz4amXuCkJl7PWghNnvYt4m3KQkpsFvnQsnxIio1K2d49h8FDeXnmkSF3Xq8eMzsJ9kz_Fen7DzO2gR4FBdwItZU_oqaXb3uaozEPoyyVZIOf83KXuozDBjCAcEtCSmDfYMuVZQtDP2n_8WhhYyHOFn8TPY2NR5bZX5JmRdRuzBR1mA8mI1vRabMAhL2fNlXJb9fX6B8Yi9KJ8ezPtDYvS_joPoFU-jyUbpHBgnEIkHUp63QGx3fETUfFN4BabDHGag0It77CUYXpQaln1CktkHxV95aRacQHY68vC3fhA7RkIRVjWG3KLiVrAB3fA5xMIQi8SVJ6VfGAmGkjjc.imF-TXh0f9YudftJ6ZkS8A","options":{"x509":{},"ssh":{}}}
                 - {"type":"ACME","name":"acme"}
             tls:
               cipherSuites:
@@ -115,16 +115,16 @@ spec:
       secrets:
         # ca_password contains the password used to encrypt x509.intermediate_ca_key, ssh.host_ca_key and ssh.user_ca_key
         # This value must be base64 encoded.
-        ca_password: "${step-ca_password}"
-        provisioner_password: "${step-ca_password}"
+        ca_password: "${stepCa_password}"
+        provisioner_password: "${stepCa_password}"
 
         x509:
           # intermediate_ca_key contains the contents of your encrypted intermediate CA key
-          intermediate_ca_key: "${step-ca_intermediate_ca_key}"
+          intermediate_ca_key: "${stepCa_intermediate_ca_key}"
 
 
           # root_ca_key contains the contents of your encrypted root CA key
           # Note that this value can be omitted without impacting the functionality of step-certificates
           # If supplied, this should be encrypted using a unique password that is not used for encrypting
           # the intermediate_ca_key, ssh.host_ca_key or ssh.user_ca_key.
-          root_ca_key: "${step-ca_root_ca_key}"
+          root_ca_key: "${stepCa_root_ca_key}"


### PR DESCRIPTION
This pull request updates the naming convention for step-ca secret keys and their references across both the encrypted values file and the Smallstep CA configuration. The main change is switching from kebab-case (e.g., `step-ca_password`) to camelCase (e.g., `stepCa_password`) for all step-ca related secrets, ensuring consistency and reducing potential for misconfiguration.

**Secret key renaming and reference updates:**

* Updated all step-ca secret keys in `kubernetes/clusters/bootstrap00/step-ca.values.sops.yaml` from kebab-case (e.g., `step-ca_password`) to camelCase (e.g., `stepCa_password`). All encrypted values have been regenerated.
* Updated references to these secret keys in `kubernetes/infrastructure/bootstrap00/smallstep.yaml` to use the new camelCase names (e.g., `${stepCa_password}` instead of `${step-ca_password}`) in both the `spec.secrets` and `spec.provisioners` sections. [[1]](diffhunk://#diff-32df6880d6eb478d9227deea55acf51e4fd50c7288317a4fecefce054baf4724L63-R63) [[2]](diffhunk://#diff-32df6880d6eb478d9227deea55acf51e4fd50c7288317a4fecefce054baf4724L118-R130)

**SOPS metadata update:**

* Updated the SOPS metadata in `step-ca.values.sops.yaml` to reflect the new encryption (new `lastmodified` and `mac`).