### PR TITLE
fix: add missing sops decryption information

### DIFF
--- a/kubernetes/clusters/bootstrap00/infrastructure.yaml
+++ b/kubernetes/clusters/bootstrap00/infrastructure.yaml
@@ -59,6 +59,10 @@ spec:
   path: ./kubernetes/infrastructure/bootstrap00
   prune: true
   wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
   postBuild:
     substituteFrom:
       - kind: Secret


### PR DESCRIPTION
This pull request introduces a configuration update to the `kubernetes/clusters/bootstrap00/infrastructure.yaml` file, specifically adding decryption settings to support secret management with SOPS and AGE.

Secret management improvements:

* Added a `decryption` section to specify `sops` as the decryption provider and reference the `sops-age` secret, enabling automated decryption of secrets during cluster bootstrapping.