### PR TITLE
fix: Add quotes to one subtitution varibale

### DIFF
--- a/kubernetes/infrastructure/bootstrap00/smallstep.yaml
+++ b/kubernetes/infrastructure/bootstrap00/smallstep.yaml
@@ -85,7 +85,7 @@ spec:
               renegotiation: false
 
           defaults.json:
-            ca-url: https://ca.${mgmtDomainOld}
+            ca-url: "https://ca.${mgmtDomainOld}"
             ca-config: /home/step/config/ca.json
             fingerprint: ba796b5752c9481ce8d321ce8cc74e5f6af1e08b9d611384d236b94c2264594e
             root: /home/step/certs/root_ca.crt


### PR DESCRIPTION
This pull request makes a minor formatting adjustment to the `smallstep.yaml` configuration file. The change ensures that the `ca-url` value is explicitly treated as a string, which can help prevent parsing issues in certain YAML processors.

- Quoted the `ca-url` value in the `defaults.json` section to ensure correct YAML parsing.