### PR TITLE
fix: correct step-certificates versionning

### DIFF
--- a/kubernetes/infrastructure/bootstrap00/smallstep/smallstep.yaml
+++ b/kubernetes/infrastructure/bootstrap00/smallstep/smallstep.yaml
@@ -26,7 +26,7 @@ spec:
   chart:
     spec:
       chart: step-certificates
-      version: ">=1.19.4 <1.20.0"
+      version: ">=1.30.1 <1.31.0"
       sourceRef:
         kind: HelmRepository
         name: smallstep


### PR DESCRIPTION
This pull request updates the version constraint for the `step-certificates` Helm chart in the `smallstep.yaml` Kubernetes bootstrap configuration. The chart version is now pinned to the `1.30.x` series, allowing for newer features and fixes within that minor version.

Helm chart version update:

* Updated the `step-certificates` Helm chart version constraint from `>=1.19.4 <1.20.0` to `>=1.30.1 <1.31.0` in `smallstep.yaml` to use a more recent minor version.