### PR TITLE
fix: httpRoute wrong service ref name

### DIFF
--- a/kubernetes/apps/bootstrap00/ca/http-route.yaml
+++ b/kubernetes/apps/bootstrap00/ca/http-route.yaml
@@ -15,27 +15,27 @@ spec:
   rules:
     - name: https
       backendRefs:
-        - name: https
+        - name: step-certificates
           port: 443
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: ca-mgmt-http
-  namespace: smallstep
-spec:
-  parentRefs:
-    - name: ca-mgmt
-      namespace: smallstep
-      sectionName: http
-      port: 80
-  hostnames:
-    - "ca.${mgmtDomainOld}"
-  rules:
-    - name: http
-      backendRefs:
-        - name: https
-          port: 443
+# ---
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: HTTPRoute
+# metadata:
+#   name: ca-mgmt-http
+#   namespace: smallstep
+# spec:
+#   parentRefs:
+#     - name: ca-mgmt
+#       namespace: smallstep
+#       sectionName: http
+#       port: 80
+#   hostnames:
+#     - "ca.${mgmtDomainOld}"
+#   rules:
+#     - name: http
+#       backendRefs:
+#         - name: step-certificates
+#           port: 443
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -53,24 +53,24 @@ spec:
   rules:
     - name: https
       backendRefs:
-        - name: https
+        - name: step-certificates
           port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: ca-service-http
-  namespace: smallstep
-spec:
-  parentRefs:
-    - name: ca-service
-      namespace: smallstep
-      sectionName: http
-      port: 80
-  hostnames:
-    - "ca.${serviceDomainOld}"
-  rules:
-    - name: http
-      backendRefs:
-        - name: https
-          port: 443
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: HTTPRoute
+# metadata:
+#   name: ca-service-http
+#   namespace: smallstep
+# spec:
+#   parentRefs:
+#     - name: ca-service
+#       namespace: smallstep
+#       sectionName: http
+#       port: 80
+#   hostnames:
+#     - "ca.${serviceDomainOld}"
+#   rules:
+#     - name: http
+#       backendRefs:
+#         - name: step-certificates
+#           port: 443

--- a/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
@@ -27,6 +27,7 @@ metadata:
     app: netbootxyz
     network: mgmt
   annotations:
+    lbipam.cilium.io/ips: "${bootstrapMgmtIpv4},${bootstrapMgmtIpv6}"
     lbipam.cilium.io/sharing-key: mgmt-bootstrap
 spec:
   ports:
@@ -47,6 +48,7 @@ metadata:
     app: netbootxyz
     network: service
   annotations:
+    lbipam.cilium.io/ips: "${bootstrapServiceIpv4},${bootstrapServiceIpv6}"
     lbipam.cilium.io/sharing-key: service-bootstrap
 spec:
   ports:
@@ -67,6 +69,7 @@ metadata:
     app: netbootxyz
     network: k8s00
   annotations:
+    lbipam.cilium.io/ips: "${bootstrapK8s00Ipv4},${bootstrapK8s00Ipv6}"
     lbipam.cilium.io/sharing-key: k8s00-bootstrap
 spec:
   ports:

--- a/kubernetes/apps/bootstrap00/unifi/services.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/services.yaml
@@ -27,6 +27,7 @@ metadata:
     app: unifi-network-application
     network: mgmt
   annotations:
+    lbipam.cilium.io/ips: "${bootstrapMgmtIpv4},${bootstrapMgmtIpv6}"
     lbipam.cilium.io/sharing-key: mgmt-bootstrap
 spec:
   ports:


### PR DESCRIPTION
This pull request makes updates to Kubernetes service and HTTPRoute configurations to improve load balancer IP management and clarify backend references. The most significant changes involve specifying explicit IP addresses for services using Cilium's IPAM annotations and updating HTTPRoute backend references to use the correct service name.

**Load Balancer IP Management Improvements:**

* Added the `lbipam.cilium.io/ips` annotation to the `netbootxyz` services in the `mgmt`, `service`, and `k8s00` networks to explicitly assign IPv4 and IPv6 addresses via environment variables. (`kubernetes/apps/bootstrap00/netbootxyz/services.yaml`) [[1]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351R30) [[2]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351R51) [[3]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351R72)
* Added the `lbipam.cilium.io/ips` annotation to the `unifi-network-application` service in the `mgmt` network for explicit IP assignment. (`kubernetes/apps/bootstrap00/unifi/services.yaml`)

**HTTPRoute Backend Reference Updates:**

* Updated `backendRefs` in `HTTPRoute` definitions to use `step-certificates` instead of the generic `https` service name, clarifying service routing targets. (`kubernetes/apps/bootstrap00/ca/http-route.yaml`) [[1]](diffhunk://#diff-12dcdc08536413f07fd6b7da6dbd2a6d4fba5cb658ff0def8bfe2d2e45d115b0L18-R38) [[2]](diffhunk://#diff-12dcdc08536413f07fd6b7da6dbd2a6d4fba5cb658ff0def8bfe2d2e45d115b0L56-R76)