### PR TITLE
feat: improve on cluster bootstraping

### DIFF
--- a/docs/5_the_kubernetes_clusters.md
+++ b/docs/5_the_kubernetes_clusters.md
@@ -93,6 +93,8 @@ flux create source git homelab \
 flux create kustomization {cluster_name} \
   --source=GitRepository/homelab \
   --path=./kubernetes/clusters/{cluster_name} \
+  --decryption-provider=sops \
+  --decryption-secret=sops-age
   --prune=true \
   --interval=10m
 ```

--- a/docs/5_the_kubernetes_clusters.md
+++ b/docs/5_the_kubernetes_clusters.md
@@ -94,7 +94,7 @@ flux create kustomization {cluster_name} \
   --source=GitRepository/homelab \
   --path=./kubernetes/clusters/{cluster_name} \
   --decryption-provider=sops \
-  --decryption-secret=sops-age
+  --decryption-secret=sops-age \
   --prune=true \
   --interval=10m
 ```

--- a/kubernetes/starter/bootstrap00/bootstrap/cert-manager/kustomization.yaml
+++ b/kubernetes/starter/bootstrap00/bootstrap/cert-manager/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: cert-manager
+    repo: https://charts.jetstack.io
+    releaseName: cert-manager
+    namespace: cert-manager
+    version: 1.20.2
+    valuesInline:
+      crds:
+        enabled: true

--- a/kubernetes/starter/bootstrap00/bootstrap/cilium/kustomization.yaml
+++ b/kubernetes/starter/bootstrap00/bootstrap/cilium/kustomization.yaml
@@ -44,3 +44,5 @@ helmCharts:
         enabled: true
       operator:
         replicas: 1
+      bgpControlPlane:
+        enabled: true

--- a/kubernetes/starter/bootstrap00/bootstrap/kustomization.yaml
+++ b/kubernetes/starter/bootstrap00/bootstrap/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cilium
+  - cert-manager

--- a/kubernetes/starter/k8s00/bootstrap/cert-manager/kustomization.yaml
+++ b/kubernetes/starter/k8s00/bootstrap/cert-manager/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: cert-manager
+    repo: https://charts.jetstack.io
+    releaseName: cert-manager
+    namespace: cert-manager
+    version: 1.20.2
+    valuesInline:
+      crds:
+        enabled: true

--- a/kubernetes/starter/k8s00/bootstrap/cilium/kustomization.yaml
+++ b/kubernetes/starter/k8s00/bootstrap/cilium/kustomization.yaml
@@ -37,3 +37,5 @@ helmCharts:
       cni:
         exclusive: false
       devices: br0
+      bgpControlPlane:
+        enabled: true

--- a/kubernetes/starter/k8s00/bootstrap/kustomization.yaml
+++ b/kubernetes/starter/k8s00/bootstrap/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cilium
+  - cert-manager


### PR DESCRIPTION
This pull request introduces several improvements to the Kubernetes cluster bootstrap process, focusing on enhancing networking capabilities and adding certificate management. The most notable changes are the integration of cert-manager via Helm charts, enabling BGP control plane in Cilium configurations, and updating documentation for SOPS decryption.

**Cert-manager integration:**

* Added `cert-manager` as a Helm chart in both `starter/bootstrap00` and `starter/k8s00` environments, ensuring CRDs are enabled (`kubernetes/starter/bootstrap00/bootstrap/cert-manager/kustomization.yaml`, `kubernetes/starter/k8s00/bootstrap/cert-manager/kustomization.yaml`).
* Updated `kustomization.yaml` files to include `cert-manager` as a managed resource in both environments (`kubernetes/starter/bootstrap00/bootstrap/kustomization.yaml`, `kubernetes/starter/k8s00/bootstrap/kustomization.yaml`).

**Networking enhancements:**

* Enabled the BGP control plane in Cilium Helm chart values for both environments to support advanced networking features (`kubernetes/starter/bootstrap00/bootstrap/cilium/kustomization.yaml`, `kubernetes/starter/k8s00/bootstrap/cilium/kustomization.yaml`). [[1]](diffhunk://#diff-e6875c694f98cc4ff42b0183a1839ca7a37364a43e453e425c98dc999ae5adeaR47-R48) [[2]](diffhunk://#diff-8c680db7d998ef5d971986eb4f41b9b0f3f523f667b088a364e44cdf6e9e23dfR40-R41)

**Documentation update:**

* Updated the Flux installation documentation to include SOPS decryption provider and secret flags for enhanced security in GitOps workflows (`docs/5_the_kubernetes_clusters.md`).