### PR TITLE
fix: unifi networking between services

### DIFF
--- a/kubernetes/apps/bootstrap00/unifi/services.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/services.yaml
@@ -58,10 +58,12 @@ metadata:
   labels:
     app: mongodb
 spec:
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
   ports:
     - name: mongodb
       port: 27017
       targetPort: 27017
   selector:
     app: mongodb
-  clusterIP: None

--- a/kubernetes/apps/bootstrap00/unifi/unifi-network-application.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/unifi-network-application.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: unifi-network-application
-          image: lscr.io/linuxserver/unifi-network-application:10.3.58
+          image: lscr.io/linuxserver/unifi-network-application:10.4.57
           imagePullPolicy: IfNotPresent
           env:
             - name: MONGO_AUTHSOURCE


### PR DESCRIPTION
This pull request makes updates to the Unifi Network Application deployment and MongoDB service configuration in the Kubernetes manifests. The main changes include updating the Unifi container image to a newer version and modifying the MongoDB service to explicitly use IPv4 networking.

**Unifi Network Application Update:**

* Updated the `unifi-network-application` container image from version `10.3.58` to `10.4.57` in `unifi-network-application.yaml`, ensuring the application runs the latest release.

**MongoDB Service Networking Configuration:**

* Modified the MongoDB service in `services.yaml` to specify `ipFamilies: [IPv4]` and `ipFamilyPolicy: SingleStack`, enforcing the use of IPv4 for the service. Also removed the `clusterIP: None` setting, which previously configured the service as headless.