### PR TITLE
fix: cilium bgp add missing ipv4 config

### DIFF
--- a/kubernetes/infrastructure/bootstrap00/cilium/bgp-cluster-config.yaml
+++ b/kubernetes/infrastructure/bootstrap00/cilium/bgp-cluster-config.yaml
@@ -8,14 +8,14 @@ spec:
     matchLabels:
       kubernetes.io/os: linux
   bgpInstances:
-    # - name: "service-bootstrap-ipv4-64514"
-    #   localASN: 64514
-    #   peers:
-    #     - name: "opnsense-service-bootstrap"
-    #       peerASN: 64512
-    #       peerAddress: "${ipv4_mgmt_prouter}"
-    #       peerConfigRef:
-    #         name: "cilium-peer"
+    - name: "service-bootstrap-ipv4-64514"
+      localASN: 64514
+      peers:
+        - name: "opnsense-service-bootstrap"
+          peerASN: 64512
+          peerAddress: "${ipv4_mgmt_router}"
+          peerConfigRef:
+            name: "cilium-peer"
     - name: "service-bootstrap-ipv6-64514"
       localASN: 64514
       peers:


### PR DESCRIPTION
This pull request re-enables and updates a BGP instance configuration in the `cilium/bgp-cluster-config.yaml` file, which is part of the Kubernetes infrastructure bootstrap process. The main change is activating a previously commented-out IPv4 BGP instance and correcting a variable name for the peer address.

**BGP Instance Configuration Updates:**

* Reactivated the `service-bootstrap-ipv4-64514` BGP instance by uncommenting its configuration and ensured it is included in the `bgpInstances` list.
* Updated the peer address variable from `${ipv4_mgmt_prouter}` to `${ipv4_mgmt_router}` for the `opnsense-service-bootstrap` peer, correcting the reference and likely fixing a configuration error.