### PR TITLE
feat: bootstrap00: add external-dns

### DIFF
--- a/kubernetes/clusters/bootstrap00/cilium.values.sops.yaml
+++ b/kubernetes/clusters/bootstrap00/cilium.values.sops.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cilium-values
   namespace: flux-system
 stringData:
-  ipv4_mgmt_router: ENC[AES256_GCM,data:MmN0N6/MxkEl++Sz,iv:JAzrt1qZ7ZX2KLCYLOqKpC9WPpe+9yx5GECTFv3LB4E=,tag:36PH1C2Vq6Fb5lGr2ewbdQ==,type:str]
+  ipv4_mgmt_router: ENC[AES256_GCM,data:6ZwkHRW4YTWk8Ww=,iv:iDk7amLt6LNCj1KR/g2X7aD0d8mZI56P03KA/mS9JV0=,tag:g42OUJ6O5SHQEGio4qvBGw==,type:str]
   ipv6_mgmt_router: ENC[AES256_GCM,data:O0QV3073yJcg49nkwHAenoX6KlwrfQc6TR1xu/2Oq23e3zsZN0Wi,iv:stcO2oEul2ef11/RmKe+g4K0GUI/BvqccEd3gSu/x/I=,tag:MfGeTzRZQv84zENOL4l+FQ==,type:str]
   ipv4_mgmt_bgp_cidr: ENC[AES256_GCM,data:QaRsJjIec+KfCjsETi0=,iv:65sOiQRET/aiyvQjpT/bBWDRtIc2Znj30gRI8zQIHl0=,tag:HDRcHmqMa+MS1B6uwjlJDw==,type:str]
   ipv6_mgmt_bgp_cidr: ENC[AES256_GCM,data:dTnQ17xXamruoOgI8hGdcH+OBespAHIGuQ==,iv:R1YcHr/Le/KAVaFGDlPwwnE3OXNTjqhGEAQVqEilnIA=,tag:94LcgGRCUPzLgoKrUCXzlQ==,type:str]
@@ -26,6 +26,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-05-30T03:58:18Z"
-  mac: ENC[AES256_GCM,data:Bj120y040pYUFfL1bzyMAahzn1bC2TIlPVeaPYKRE9cuyU4b8aUriiKkSXxFzWlu0U2U9NZAqQi6qNW/oicORKCd0kyPn7SrHamyY/o6Un6b5KBwsSE8+XBW7JEpaNSTlC+tn9ulbbh+s82fIzxYSRvnpPTHMR5qYPThS2a/Ts4=,iv:IvcC6N4C8vfyrPOu4fZz5lYw2m5a8uXCdZGfrfmUy+0=,tag:sJiCxTdkzX3WZ8sUuSSJAw==,type:str]
+  lastmodified: "2026-06-07T15:38:13Z"
+  mac: ENC[AES256_GCM,data:ivVkF7K5krsy51EpRvRGYgMHRkiTkAUX1qE5tinZOwDdAlda3qa+Wh16StcdrLXUniOg8+grGBLO1tIql2d5ycNC6TIUzLV7az4QJliONjgC2wN/R1vNDFwGDQv4Lvx2JrFb5ElG8D/lGMoVx1FOWOt6GLylGC/UhmB8nA8rbVQ=,iv:j0orfYLF/T9FQ4yXrSrm1lTsMZLuFOJcsyklyHcfRoY=,tag:CetutC4dkCIQJJkGSK37IQ==,type:str]
   version: 3.13.1

--- a/kubernetes/clusters/bootstrap00/global.values.sops.yaml
+++ b/kubernetes/clusters/bootstrap00/global.values.sops.yaml
@@ -24,6 +24,7 @@ stringData:
   caMgmtIpv6: ENC[AES256_GCM,data:zLTtaBmpnVC5PyN6i9S38zUEmSv5QGA=,iv:0vEmH1PV6zZFPaDtQ5VHJtGSvL5/qo7FmyPSIDDsRgQ=,tag:uumpgZ6Dxv+0dRpa0wb6QA==,type:str]
   caServiceIpv4: ENC[AES256_GCM,data:Nxebg/k0lUZNDXQTLw==,iv:WcG81uUhQZmSFTBH4zfN+9dHZP3pmMR1we8oC2diLJ0=,tag:pVXWO3bsLKVZqjqOwH5tZQ==,type:str]
   caServiceIpv6: ENC[AES256_GCM,data:v8sBWHbA2oeiYH+VuGmsyIXPSTf6QuM=,iv:8uY/dljhJBFXqMpLCFNgGDlAfNaFrboSiXnsk1hy3Ww=,tag:261oDenmheScHsIGXNXtzA==,type:str]
+  piholeUrl: ENC[AES256_GCM,data:TLIUR6oot54Z7Bb5LUg34Zmtyu0SWKu/N8BdddKtQVS7bIiouizJiE+64fXMbA==,iv:hMXkxSU+aRvtPhc3A1y49n6/uUKvUbXzxf8z8Vg56VM=,tag:Nt6Yda+PPaJa8ra/c20Q8Q==,type:str]
 sops:
   age:
     - enc: |
@@ -36,6 +37,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-06T18:55:45Z"
-  mac: ENC[AES256_GCM,data:WHGsuP1vJZM5Z6Sf/5IOQ1h/V4EClQUU7zk2hxOsrOg6AlB1ZJ69I2qYT+CDs9Sa5+mYIs4naExg3/uKQ0LgzG6n20wmLhKKeBN91iGQupgryIWyPQUXljk9smN5AHDFhBG2pV603Z4DRL8IVpvYbECyuo5/T4uvUmPvHo1R9n4=,iv:uSNWwa1hR2dbRlrYDfTqgKDHv1YV42obHeaTXrJp8dY=,tag:lcB3OS3SW2wJrSKWp4sSGA==,type:str]
+  lastmodified: "2026-06-07T16:24:00Z"
+  mac: ENC[AES256_GCM,data:Hb86Jcx6lcYGhdZkfIJaiaoEUU/XFu8pAmdU3JsZup8I2kZdFfb84LqENTEegN0GvHoMs8yqeqp/i2hGs/e5uXZFmULNmtfqMTcQS7gpmdpiPOgib0DmR9UQ/BeXZighG6lpvyurHvTnkDZAgEqEk9vDtDWIU56slPIdN02dyfU=,iv:IxdnzMk8Rc5M58yGyEUlIO37iiACK6r1/loPoNCFSnY=,tag:3rS3vHTtK64ltEiIA+8Ipg==,type:str]
   version: 3.13.1

--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns.secret.sops.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns.secret.sops.yaml
@@ -1,8 +1,22 @@
----
 apiVersion: v1
 kind: Secret
 metadata:
   name: pihole-password
   namespace: cert-manager
 stringData:
-  EXTERNAL_DNS_PIHOLE_PASSWORD: F3uill3 aut0mne
+  EXTERNAL_DNS_PIHOLE_PASSWORD: ENC[AES256_GCM,data:XtNZiGleki7JaTAvypAX,iv:+oQoXJJpyw11u1PARpTiiIuRYBoG6H2V5TJXCcgLUBI=,tag:rI7PT74x5DdoHgQSNje0jg==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBweXRWY05FMFpyZDR5eVBK
+        eEQ4bk1JM0JaWGhRRFJtNE1QS2svRFliZmlnCjl4eUpVM2hhUDk4SFFpRis2NWVm
+        eVVzUUZ4SThKTUVQMnBKVEdINWxaLzQKLS0tIEs0MHZoS0Fzc2srMFpwU1lxT1Bw
+        eVdQSFg4NjZ6Ui8reTNhaDdwVG5RZzAKTD29J30A/uVnj8dFEJ+A0ADt9Wa/Oc5S
+        s+fJpKrhVbxj1HUy0iopZCMqAS7C0Cih2fzMZqRi1SYMxx7zP86hKg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-07T17:19:13Z"
+  mac: ENC[AES256_GCM,data:qOd3FjWTGqfSf/qrBajhcM9cvWP4+noIunlYKnn8TcS1MkxFw391rlXOzeJG0PaspUKI1AqVhHjIZVelSRurV9LOgkD+21wHBDYdHr10A44rONxqSS1udp0stdP2TWRmIizLVbQAa+Cgy+XIoVb/1Rk7eVjiHz3NyZOrbWNNzEg=,iv:ytdh+9N5qE9xtZvaUbrOAbmK4S73A3FGQKMpp5OrNhs=,tag:qf0M1JWKQ4C7Psg4+4NS5g==,type:str]
+  version: 3.13.1

--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns.secret.sops.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns.secret.sops.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pihole-password
+  namespace: cert-manager
+stringData:
+  EXTERNAL_DNS_PIHOLE_PASSWORD: F3uill3 aut0mne

--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: external-dns
+  namespace: cert-manager
+spec:
+  interval: 1440m
+  url: https://github.com/kubernetes-sigs/external-dns
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: external-dns
+  namespace: cert-manager
+spec:
+  interval: 1440m
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: external-dns
+  path: ./kustomize
+  targetNamespace: cert-manager
+  prune: true
+  wait: true
+  patches:
+    - patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/args
+          value:
+            - --source=service
+            - --source=ingress
+            # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+            # You don't need to set this flag, but if you leave it unset, you will receive warning
+            # logs when ExternalDNS attempts to create TXT records.
+            - --registry=noop
+            # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+            # the policy to upsert-only so they do not get deleted.
+            - --policy=upsert-only
+            - --provider=pihole
+            # Switch to pihole V6 API
+            - --pihole-api-version=6
+            # Change this to the actual address of your Pi-hole web server
+            - --pihole-server=${piholeUrl}
+            - --pihole-tls-skip-verify
+        - op: add
+          path: /spec/template/spec/containers/0/envFrom
+          value:
+            - secretRef:
+                # Change this if you gave the secret a different name
+                name: pihole-password
+      target:
+        kind: Deployment
+        name: external-dns


### PR DESCRIPTION
This pull request introduces configuration and secret management for deploying ExternalDNS with Pi-hole as a DNS provider in the `cert-manager` namespace. It adds the necessary manifests, secrets, and configuration values to enable integration, while also updating related encrypted values.

**ExternalDNS with Pi-hole Integration:**

* Added a new `external-dns.yaml` manifest that sets up a `GitRepository` and `Kustomization` for ExternalDNS, including a patch to configure it for Pi-hole as the DNS provider, with all required arguments and environment variables.
* Introduced a new Kubernetes `Secret` (`external-dns.secret.sops.yaml`) containing the Pi-hole API password for ExternalDNS to authenticate with Pi-hole.

**Configuration and Secrets Management:**

* Added an encrypted `piholeUrl` entry to `global.values.sops.yaml` for securely referencing the Pi-hole server address in configuration.
* Updated SOPS metadata (`lastmodified`, `mac`) in both `cilium.values.sops.yaml` and `global.values.sops.yaml` to reflect the new encrypted content and maintain integrity. [[1]](diffhunk://#diff-3adeb628f202dd806385c6ddb6616808cdd15b8d031afd369556d8351235386dL29-R30) [[2]](diffhunk://#diff-28a8f6cdd841b219e537df086be2dee093c292f88cac4b68ccf0cb309592b6bfL39-R41)
* Rotated the encrypted value for `ipv4_mgmt_router` in `cilium.values.sops.yaml` for improved security.