### PR TITLE
fix: bootstrap00: change httpRoute name from https to http

### DIFF
--- a/kubernetes/apps/bootstrap00/netbootxyz/http-route.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/http-route.yaml
@@ -32,7 +32,7 @@ spec:
   hostnames:
     - "netbootxyz.bootstrap.${mgmtDomainOld}"
   rules:
-    - name: https
+    - name: http
       backendRefs:
         - name: netbootxyz
           port: 80
@@ -51,7 +51,7 @@ spec:
   hostnames:
     - "netbootxyz.bootstrap.${serviceDomainOld}"
   rules:
-    - name: https
+    - name: http
       backendRefs:
         - name: netbootxyz
           port: 80


### PR DESCRIPTION
This pull request makes a minor update to the `kubernetes/apps/bootstrap00/netbootxyz/http-route.yaml` file. The main change is renaming the route rules from "https" to "http" for both management and service domains, likely to accurately reflect the backend protocol being used.

- Changed route rule names from "https" to "http" for the `netbootxyz.bootstrap.${mgmtDomainOld}` and `netbootxyz.bootstrap.${serviceDomainOld}` hostnames to match the backend protocol. [[1]](diffhunk://#diff-11cf2631a11084f6cb963bd18c25551c9efbd942b6dd487e153037ad836ec82bL35-R35) [[2]](diffhunk://#diff-11cf2631a11084f6cb963bd18c25551c9efbd942b6dd487e153037ad836ec82bL54-R54)