### PR TITLE
fix: bootstrap00: external-dns: change source from ingress to gateway-api httpRoute

### DIFF
--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns.yaml
@@ -30,7 +30,7 @@ spec:
           path: /spec/template/spec/containers/0/args
           value:
             - --source=service
-            - --source=ingress
+            - --source=gateway-httproute
             # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
             # You don't need to set this flag, but if you leave it unset, you will receive warning
             # logs when ExternalDNS attempts to create TXT records.


### PR DESCRIPTION
This pull request makes a targeted update to the ExternalDNS configuration by changing the source of DNS records from `ingress` to `gateway-httproute` in the Kubernetes manifest. This reflects a shift in how DNS records are discovered, likely aligning with a migration from Ingress resources to Gateway API resources.

**ExternalDNS configuration update:**

* Changed the container argument in `external-dns.yaml` from `--source=ingress` to `--source=gateway-httproute` to support Gateway API resources instead of Ingress resources.