### PR TITLE
fix: bootstrap00: ca: switch from gateway to loadbalancer

### DIFF
--- a/kubernetes/apps/bootstrap00/ca/http-route.yaml
+++ b/kubernetes/apps/bootstrap00/ca/http-route.yaml
@@ -1,76 +1,76 @@
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: ca-mgmt-https
-  namespace: smallstep
-spec:
-  parentRefs:
-    - name: ca-mgmt
-      namespace: smallstep
-      sectionName: https
-      port: 443
-  hostnames:
-    - "ca.${mgmtDomainOld}"
-  rules:
-    - name: https
-      backendRefs:
-        - name: step-certificates
-          port: 443
 # ---
 # apiVersion: gateway.networking.k8s.io/v1
 # kind: HTTPRoute
 # metadata:
-#   name: ca-mgmt-http
+#   name: ca-mgmt-https
 #   namespace: smallstep
 # spec:
 #   parentRefs:
 #     - name: ca-mgmt
 #       namespace: smallstep
-#       sectionName: http
-#       port: 80
+#       sectionName: https
+#       port: 443
 #   hostnames:
 #     - "ca.${mgmtDomainOld}"
 #   rules:
-#     - name: http
+#     - name: https
 #       backendRefs:
 #         - name: step-certificates
 #           port: 443
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: ca-service-https
-  namespace: smallstep
-spec:
-  parentRefs:
-    - name: ca-service
-      namespace: smallstep
-      sectionName: https
-      port: 443
-  hostnames:
-    - "ca.${serviceDomainOld}"
-  rules:
-    - name: https
-      backendRefs:
-        - name: step-certificates
-          port: 443
----
+# # ---
+# # apiVersion: gateway.networking.k8s.io/v1
+# # kind: HTTPRoute
+# # metadata:
+# #   name: ca-mgmt-http
+# #   namespace: smallstep
+# # spec:
+# #   parentRefs:
+# #     - name: ca-mgmt
+# #       namespace: smallstep
+# #       sectionName: http
+# #       port: 80
+# #   hostnames:
+# #     - "ca.${mgmtDomainOld}"
+# #   rules:
+# #     - name: http
+# #       backendRefs:
+# #         - name: step-certificates
+# #           port: 443
+# ---
 # apiVersion: gateway.networking.k8s.io/v1
 # kind: HTTPRoute
 # metadata:
-#   name: ca-service-http
+#   name: ca-service-https
 #   namespace: smallstep
 # spec:
 #   parentRefs:
 #     - name: ca-service
 #       namespace: smallstep
-#       sectionName: http
-#       port: 80
+#       sectionName: https
+#       port: 443
 #   hostnames:
 #     - "ca.${serviceDomainOld}"
 #   rules:
-#     - name: http
+#     - name: https
 #       backendRefs:
 #         - name: step-certificates
 #           port: 443
+# ---
+# # apiVersion: gateway.networking.k8s.io/v1
+# # kind: HTTPRoute
+# # metadata:
+# #   name: ca-service-http
+# #   namespace: smallstep
+# # spec:
+# #   parentRefs:
+# #     - name: ca-service
+# #       namespace: smallstep
+# #       sectionName: http
+# #       port: 80
+# #   hostnames:
+# #     - "ca.${serviceDomainOld}"
+# #   rules:
+# #     - name: http
+# #       backendRefs:
+# #         - name: step-certificates
+# #           port: 443

--- a/kubernetes/apps/bootstrap00/gateway.yaml
+++ b/kubernetes/apps/bootstrap00/gateway.yaml
@@ -18,11 +18,11 @@ spec:
     - name: http
       port: 80
       protocol: HTTP
-      hostname: "*.${mgmtDomainOld}"
+      hostname: "*.bootstrap.${mgmtDomainOld}"
     - name: https
       protocol: HTTPS
       port: 443
-      hostname: "*.${mgmtDomainOld}"
+      hostname: "*.bootstrap.${mgmtDomainOld}"
       tls:
         mode: Terminate
         certificateRefs:
@@ -30,39 +30,39 @@ spec:
     # - name: http-unifi
     #   port: 8080
     #   protocol: HTTP
-    #   hostname: "*.${mgmtDomainOld}"
+    #   hostname: "*.bootstrap.${mgmtDomainOld}"
     # - name: https-unifi
     #   port: 8443
     #   protocol: HTTPS
-    #   hostname: "*.${mgmtDomainOld}"
+    #   hostname: "*.bootstrap.${mgmtDomainOld}"
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: ca-mgmt
-  namespace: smallstep
-  annotations:
-    cert-manager.io/cluster-issuer: homelab-internal
-spec:
-  infrastructure:
-    annotations:
-      lbipam.cilium.io/ips: "${caMgmtIpv4},${caMgmtIpv6}"
-    labels:
-      network: mgmt
-  gatewayClassName: cilium
-  listeners:
-    - name: http
-      port: 80
-      protocol: HTTP
-      hostname: "*.${mgmtDomainOld}"
-    - name: https
-      protocol: HTTPS
-      port: 443
-      hostname: "*.${mgmtDomainOld}"
-      tls:
-        mode: Terminate
-        certificateRefs:
-          - name: ca-mgmt-wildcard
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: Gateway
+# metadata:
+#   name: ca-mgmt
+#   namespace: smallstep
+#   annotations:
+#     cert-manager.io/cluster-issuer: homelab-internal
+# spec:
+#   infrastructure:
+#     annotations:
+#       lbipam.cilium.io/ips: "${caMgmtIpv4},${caMgmtIpv6}"
+#     labels:
+#       network: mgmt
+#   gatewayClassName: cilium
+#   listeners:
+#     - name: http
+#       port: 80
+#       protocol: HTTP
+#       hostname: "*.${mgmtDomainOld}"
+#     - name: https
+#       protocol: HTTPS
+#       port: 443
+#       hostname: "*.${mgmtDomainOld}"
+#       tls:
+#         mode: Terminate
+#         certificateRefs:
+#           - name: ca-mgmt-wildcard
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -82,33 +82,33 @@ spec:
       port: 80
       protocol: HTTP
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: ca-service
-  namespace: smallstep
-  annotations:
-    cert-manager.io/cluster-issuer: homelab-internal
-spec:
-  infrastructure:
-    annotations:
-      lbipam.cilium.io/ips: "${caServiceIpv4},${caServiceIpv6}"
-    labels:
-      network: service
-  gatewayClassName: cilium
-  listeners:
-    - name: http
-      port: 80
-      protocol: HTTP
-      hostname: "*.${serviceDomainOld}"
-    - name: https
-      protocol: HTTPS
-      port: 443
-      hostname: "*.${serviceDomainOld}"
-      tls:
-        mode: Terminate
-        certificateRefs:
-          - name: ca-service-wildcard
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: Gateway
+# metadata:
+#   name: ca-service
+#   namespace: smallstep
+#   annotations:
+#     cert-manager.io/cluster-issuer: homelab-internal
+# spec:
+#   infrastructure:
+#     annotations:
+#       lbipam.cilium.io/ips: "${caServiceIpv4},${caServiceIpv6}"
+#     labels:
+#       network: service
+#   gatewayClassName: cilium
+#   listeners:
+#     - name: http
+#       port: 80
+#       protocol: HTTP
+#       hostname: "*.${serviceDomainOld}"
+#     - name: https
+#       protocol: HTTPS
+#       port: 443
+#       hostname: "*.${serviceDomainOld}"
+#       tls:
+#         mode: Terminate
+#         certificateRefs:
+#           - name: ca-service-wildcard
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -127,7 +127,7 @@ spec:
     - name: http
       port: 80
       protocol: HTTP
-# ---
+---
 # apiVersion: gateway.networking.k8s.io/v1
 # kind: Gateway
 # metadata:


### PR DESCRIPTION
This pull request updates the Kubernetes Gateway and HTTPRoute configurations for the bootstrap CA and service components. The main changes are the removal (or commenting out) of the legacy `ca-mgmt` and `ca-service` Gateway and HTTPRoute resources, and updates to the hostnames for the bootstrap Gateway listeners to ensure they use the correct subdomain. These changes help to deprecate the old CA endpoints and transition to the new bootstrap endpoints.

The most important changes are:

**Deprecation of legacy CA endpoints:**
* Removed or commented out the `ca-mgmt` and `ca-service` `Gateway` and `HTTPRoute` resources in `gateway.yaml` and `http-route.yaml`, which previously handled traffic for the old management and service domains. [[1]](diffhunk://#diff-c1e8d642698b09f53bad4c4da714e105fb5052b1cd80b8881d4c99ab3187bb0fL21-R65) [[2]](diffhunk://#diff-c1e8d642698b09f53bad4c4da714e105fb5052b1cd80b8881d4c99ab3187bb0fL85-R111) [[3]](diffhunk://#diff-12dcdc08536413f07fd6b7da6dbd2a6d4fba5cb658ff0def8bfe2d2e45d115b0L1-R76)

**Update to bootstrap hostnames:**
* Updated listener hostnames in the bootstrap Gateway to use `*.bootstrap.${mgmtDomainOld}` instead of the previous `*.${mgmtDomainOld}` pattern, ensuring that only the new bootstrap subdomains are matched.

These changes help ensure that only the intended bootstrap endpoints are exposed and that legacy endpoints are no longer configured in the cluster.