### PR TITLE
feat: bootstrap00: ca: add loadbalancer

### DIFF
--- a/kubernetes/apps/bootstrap00/ca/service.yaml
+++ b/kubernetes/apps/bootstrap00/ca/service.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ca-mgmt
+  namespace: smallstep
+  labels:
+    app: ca
+    network: mgmt
+  annotations:
+    lbipam.cilium.io/ips: "${caMgmtIpv4},${caMgmtIpv6}"
+spec:
+  ports:
+    - name: ca-server
+      port: 443
+      protocol: TCP
+      targetPort: 9000
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/instance: step-certificates
+    app.kubernetes.io/name: step-certificates
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ca-service
+  namespace: smallstep
+  labels:
+    app: ca
+    network: service
+  annotations:
+    lbipam.cilium.io/ips: "${caServiceIpv4},${caServiceIpv6}"
+spec:
+  ports:
+    - name: ca-server
+      port: 443
+      protocol: TCP
+      targetPort: 9000
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/instance: step-certificates
+    app.kubernetes.io/name: step-certificates


### PR DESCRIPTION
This pull request adds two new Kubernetes `Service` resources to the `kubernetes/apps/bootstrap00/ca/service.yaml` file. These services expose the certificate authority (CA) application on separate networks with specific IP annotations and LoadBalancer configurations.

New Kubernetes services for CA exposure:

* Added a `ca-mgmt` service in the `smallstep` namespace, labeled for the management network, exposing port 443 and annotated with `lbipam.cilium.io/ips` for management IP allocation.
* Added a `ca-service` service in the `smallstep` namespace, labeled for the service network, also exposing port 443 and annotated with `lbipam.cilium.io/ips` for service IP allocation.