### PR TITLE
fix: bootstrap00: service loadbalancer needed dual-stack to work

### DIFF
--- a/kubernetes/apps/bootstrap00/ca/service.yaml
+++ b/kubernetes/apps/bootstrap00/ca/service.yaml
@@ -10,6 +10,7 @@ metadata:
   annotations:
     lbipam.cilium.io/ips: "${caMgmtIpv4},${caMgmtIpv6}"
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
     - name: ca-server
       port: 443
@@ -31,6 +32,7 @@ metadata:
   annotations:
     lbipam.cilium.io/ips: "${caServiceIpv4},${caServiceIpv6}"
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
     - name: ca-server
       port: 443

--- a/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
@@ -30,6 +30,7 @@ metadata:
     lbipam.cilium.io/ips: "${bootstrapMgmtIpv4},${bootstrapMgmtIpv6}"
     lbipam.cilium.io/sharing-key: mgmt-bootstrap
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
     - name: web
       port: 69
@@ -51,6 +52,7 @@ metadata:
     lbipam.cilium.io/ips: "${bootstrapServiceIpv4},${bootstrapServiceIpv6}"
     lbipam.cilium.io/sharing-key: service-bootstrap
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
     - name: web
       port: 69
@@ -72,6 +74,7 @@ metadata:
     lbipam.cilium.io/ips: "${bootstrapK8s00Ipv4},${bootstrapK8s00Ipv6}"
     lbipam.cilium.io/sharing-key: k8s00-bootstrap
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
     - name: web
       port: 69

--- a/kubernetes/apps/bootstrap00/unifi/services.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/services.yaml
@@ -30,6 +30,7 @@ metadata:
     lbipam.cilium.io/ips: "${bootstrapMgmtIpv4},${bootstrapMgmtIpv6}"
     lbipam.cilium.io/sharing-key: mgmt-bootstrap
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
     - name: discovery
       port: 10001
@@ -58,9 +59,10 @@ metadata:
   labels:
     app: mongodb
 spec:
+  ipFamilyPolicy: PreferDualStack
   ipFamilies:
     - IPv4
-  ipFamilyPolicy: SingleStack
+    - IPv6
   ports:
     - name: mongodb
       port: 27017


### PR DESCRIPTION
This pull request updates several Kubernetes service manifests to improve network compatibility by enabling dual-stack (IPv4 and IPv6) support. The main change is the addition of the `ipFamilyPolicy: PreferDualStack` field to multiple services, ensuring they can utilize both IP families when available.

**Kubernetes service manifest updates:**

* Added `ipFamilyPolicy: PreferDualStack` to the `ca` service for both management and service IPs in `ca/service.yaml` to enable dual-stack support. [[1]](diffhunk://#diff-1d64e8c8c7222ea868cd3b221966bfd7241b56d1cfb36a5ab55829b15cda8699R13) [[2]](diffhunk://#diff-1d64e8c8c7222ea868cd3b221966bfd7241b56d1cfb36a5ab55829b15cda8699R35)
* Added `ipFamilyPolicy: PreferDualStack` to all `netbootxyz` services in `netbootxyz/services.yaml` for management, service, and k8s00 IPs, enhancing dual-stack compatibility. [[1]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351R33) [[2]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351R55) [[3]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351R77)
* Added `ipFamilyPolicy: PreferDualStack` to the `unifi` management service in `unifi/services.yaml`.

**MongoDB service improvements:**

* Changed the MongoDB service in `unifi/services.yaml` to use `ipFamilyPolicy: PreferDualStack` and added IPv6 to the `ipFamilies` list, replacing the previous `SingleStack` policy.