### PR TITLE
fix: bootstrap00: service loadbalancer needed dual-stack to work part2

### DIFF
--- a/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: netbootxyz
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
     - name: assets
       port: 80

--- a/kubernetes/apps/bootstrap00/unifi/services.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/services.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: unifi-network-application
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
     - name: device-comm
       port: 8080


### PR DESCRIPTION
This pull request adds improved network configuration to two Kubernetes service definitions by specifying a dual-stack IP family policy. This change ensures that both IPv4 and IPv6 addresses are preferred, increasing compatibility and flexibility in networking.

Network configuration enhancements:

* Added `ipFamilyPolicy: PreferDualStack` to the `spec` of the `netbootxyz` service in `services.yaml` to enable support for both IPv4 and IPv6.
* Added `ipFamilyPolicy: PreferDualStack` to the `spec` of the `unifi-network-application` service in `services.yaml` for dual-stack networking support.