### PR TITLE
fix: bootstrap00: unifi: add l2 discovery

### DIFF
--- a/kubernetes/apps/bootstrap00/unifi/http-route.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/http-route.yaml
@@ -16,4 +16,4 @@
 #     - name: https
 #       backendRefs:
 #         - name: unifi
-#           port: 8443
+#           port: 8880

--- a/kubernetes/apps/bootstrap00/unifi/services.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/services.yaml
@@ -12,9 +12,12 @@ spec:
     - name: device-comm
       port: 8080
       targetPort: 8080
-    - name: admin
+    - name: admin-https
       port: 8443
       targetPort: 8443
+    - name: admin-http
+      port: 8880
+      targetPort: 8880
   selector:
     app: unifi-network-application
   type: ClusterIP
@@ -37,6 +40,10 @@ spec:
       port: 10001
       protocol: UDP
       targetPort: 10001
+    - name: discovery-l2
+      port: 1900
+      protocol: UDP
+      targetPort: 1900
     - name: stun
       port: 3478
       protocol: UDP
@@ -44,7 +51,7 @@ spec:
     - name: device-comm
       port: 8080
       targetPort: 8080
-    - name: admin
+    - name: admin-https
       port: 8443
       protocol: TCP
       targetPort: 8443

--- a/kubernetes/apps/bootstrap00/unifi/unifi-network-application.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/unifi-network-application.yaml
@@ -45,6 +45,9 @@ spec:
             - containerPort: 10001
               name: discovery
               protocol: UDP
+            - containerPort: 1900
+              name: discovery-l2
+              protocol: UDP
             - containerPort: 3478
               name: stun
               protocol: UDP
@@ -52,7 +55,10 @@ spec:
               name: device-comm
               protocol: TCP
             - containerPort: 8443
-              name: admin
+              name: admin-https
+              protocol: TCP
+            - containerPort: 8880
+              name: admin-http
               protocol: TCP
           volumeMounts:
             - name: config


### PR DESCRIPTION
This pull request updates the Unifi Network Application Kubernetes configuration to improve port clarity and add support for additional service discovery. The most important changes include splitting the admin service into separate HTTP and HTTPS ports, introducing a new L2 discovery port, and updating references to these ports across the deployment, service, and route manifests.

**Service port updates:**

* Split the `admin` service into `admin-https` (port 8443) and `admin-http` (port 8880) in `services.yaml`, and updated the corresponding container ports in `unifi-network-application.yaml` to match. [[1]](diffhunk://#diff-b7c266d042c1217351f5e61a21f7abec87d81032faa4e1feee695eb4e56ec88dL15-R20) [[2]](diffhunk://#diff-88a88cbe59096c840aeb495a0b67fa2ba7ad9ea2ce56078c8d93a65db3d72694R48-R61)
* Updated the commented backend reference in `http-route.yaml` to use port 8880 (HTTP) instead of 8443 (HTTPS) for clarity.

**Discovery enhancements:**

* Added a new UDP port 1900 named `discovery-l2` to both the service (`services.yaml`) and container (`unifi-network-application.yaml`) definitions to support L2 device discovery. [[1]](diffhunk://#diff-b7c266d042c1217351f5e61a21f7abec87d81032faa4e1feee695eb4e56ec88dR43-R54) [[2]](diffhunk://#diff-88a88cbe59096c840aeb495a0b67fa2ba7ad9ea2ce56078c8d93a65db3d72694R48-R61)

**Protocol and naming consistency:**

* Ensured all port and protocol names are consistent between the service and deployment manifests, using `admin-https` and `admin-http` as appropriate. [[1]](diffhunk://#diff-b7c266d042c1217351f5e61a21f7abec87d81032faa4e1feee695eb4e56ec88dL15-R20) [[2]](diffhunk://#diff-88a88cbe59096c840aeb495a0b67fa2ba7ad9ea2ce56078c8d93a65db3d72694R48-R61)