### PR TITLE
doc: reorder k8s steps

### DIFF
--- a/docs/5_the_kubernetes_clusters.md
+++ b/docs/5_the_kubernetes_clusters.md
@@ -83,11 +83,11 @@ kubectl kustomize bootstrap --enable-helm | kubectl apply -f -
 ### Add SOPS age-key secrets
 
 ```bash
-kubectl create namespace flux-system
-cat TO_THE_AGE_KEY | \
+kubectl create namespace flux-system --dry-run=client -o yaml | kubectl apply -f -
+cat <path-to-age-key> | \
   kubectl create secret generic sops-age \
     --namespace=flux-system \
-    --from-file=age.agekey=/dev/stdin
+    --from-file=age.agekey=/dev/stdin --dry-run=client -o yaml | kubectl apply -f -
 ```
 
 ### Bootstrap fluxcd

--- a/docs/5_the_kubernetes_clusters.md
+++ b/docs/5_the_kubernetes_clusters.md
@@ -80,6 +80,16 @@ Move to the folder kubernetes/starter/{cluster_name}
 kubectl kustomize bootstrap --enable-helm | kubectl apply -f -
 ```
 
+### Add SOPS age-key secrets
+
+```bash
+kubectl create namespace flux-system
+cat TO_THE_AGE_KEY | \
+  kubectl create secret generic sops-age \
+    --namespace=flux-system \
+    --from-file=age.agekey=/dev/stdin
+```
+
 ### Bootstrap fluxcd
 
 ```bash
@@ -111,15 +121,6 @@ flux bootstrap github \
   --path=kubernetes/clusters/{cluster_name} \
   --private=false \
   --personal=true
-```
-
-### Add SOPS age-key secrets
-
-```bash
-cat TO_THE_AGE_KEY | \
-  kubectl create secret generic sops-age \
-    --namespace=flux-system \
-    --from-file=age.agekey=/dev/stdin
 ```
 
 ## Upgrades


### PR DESCRIPTION
This pull request updates the documentation for setting up Kubernetes clusters, specifically reorganizing the instructions for adding SOPS age-key secrets. The main change is moving the section about adding SOPS age-key secrets to an earlier point in the process, before bootstrapping FluxCD. This ensures the secrets are available when needed during the bootstrap process.

Documentation improvements:

* Moved the instructions for adding SOPS age-key secrets to immediately after creating the `flux-system` namespace, ensuring secrets are set up before bootstrapping FluxCD (`docs/5_the_kubernetes_clusters.md`). [[1]](diffhunk://#diff-6f39ea8a22c8b560fc38704602d846f84b477c490e73f75051f16b2654ae56afR83-R92) [[2]](diffhunk://#diff-6f39ea8a22c8b560fc38704602d846f84b477c490e73f75051f16b2654ae56afL116-L124)