### PR TITLE
fix: create cert-manager namespace during bootstrap

### DIFF
--- a/kubernetes/starter/bootstrap00/bootstrap/cert-manager/kustomization.yaml
+++ b/kubernetes/starter/bootstrap00/bootstrap/cert-manager/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+resources:
+  - namespace.yaml
 helmCharts:
   - name: cert-manager
     repo: https://charts.jetstack.io

--- a/kubernetes/starter/bootstrap00/bootstrap/cert-manager/namespace.yaml
+++ b/kubernetes/starter/bootstrap00/bootstrap/cert-manager/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager

--- a/kubernetes/starter/k8s00/bootstrap/cert-manager/kustomization.yaml
+++ b/kubernetes/starter/k8s00/bootstrap/cert-manager/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+resources:
+  - namespace.yaml
 helmCharts:
   - name: cert-manager
     repo: https://charts.jetstack.io

--- a/kubernetes/starter/k8s00/bootstrap/cert-manager/namespace.yaml
+++ b/kubernetes/starter/k8s00/bootstrap/cert-manager/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager


### PR DESCRIPTION
This pull request adds explicit namespace creation for the `cert-manager` component in both the `bootstrap00` and `k8s00` Kubernetes starter environments. This ensures that the `cert-manager` resources are deployed into the correct namespace, improving reliability and consistency during deployments.

Namespace management improvements:

* Added a new `namespace.yaml` manifest in both `kubernetes/starter/bootstrap00/bootstrap/cert-manager/` and `kubernetes/starter/k8s00/bootstrap/cert-manager/` to explicitly create the `cert-manager` namespace.
* Updated the corresponding `kustomization.yaml` files in both locations to include the new `namespace.yaml` as a resource, ensuring the namespace is created before deploying the Helm chart.