### PR TITLE
feat: bootstrap00: cilium: add l2 support

### DIFF
--- a/kubernetes/infrastructure/bootstrap00/cilium.yaml
+++ b/kubernetes/infrastructure/bootstrap00/cilium.yaml
@@ -106,3 +106,11 @@ spec:
           keepCapNetBindService: true
     operator:
       replicas: 1
+    l2announcements:
+      enabled: true
+      leaseDuration: 15s
+      leaseRenewDeadline: 5s
+      leaseRetryPeriod: 2s
+    k8sClientRateLimit:
+      qps: 5
+      burst: 10

--- a/kubernetes/infrastructure/bootstrap00/cilium/l2-announcement-policy.yaml
+++ b/kubernetes/infrastructure/bootstrap00/cilium/l2-announcement-policy.yaml
@@ -8,6 +8,6 @@ spec:
       - key: network
         operator: Exists
   interfaces:
-    - ^br0(\.[\d]+)?
+    - '^br0(\.[0-9]+)?$'
   externalIPs: true
   loadBalancerIPs: true

--- a/kubernetes/infrastructure/bootstrap00/cilium/l2-announcement-policy.yaml
+++ b/kubernetes/infrastructure/bootstrap00/cilium/l2-announcement-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: "cilium.io/v2alpha1"
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: bootstrap-l2-annoucement-policy
+spec:
+  serviceSelector:
+    matchExpressions:
+      - key: network
+        operator: Exists
+  interfaces:
+    - ^br0(\.[\d]+)?
+  externalIPs: true
+  loadBalancerIPs: true

--- a/kubernetes/infrastructure/bootstrap00/cilium/l2-announcement-policy.yaml
+++ b/kubernetes/infrastructure/bootstrap00/cilium/l2-announcement-policy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: "cilium.io/v2alpha1"
 kind: CiliumL2AnnouncementPolicy
 metadata:

--- a/kubernetes/infrastructure/bootstrap00/cilium/l2-announcement-policy.yaml
+++ b/kubernetes/infrastructure/bootstrap00/cilium/l2-announcement-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: "cilium.io/v2alpha1"
 kind: CiliumL2AnnouncementPolicy
 metadata:
-  name: bootstrap-l2-annoucement-policy
+  name: bootstrap-l2-announcement-policy
 spec:
   serviceSelector:
     matchExpressions:


### PR DESCRIPTION
This pull request enhances the Cilium networking setup in the Kubernetes bootstrap configuration by enabling and configuring Layer 2 (L2) announcements and introducing a new L2 announcement policy. These changes aim to improve service IP advertisement and control over network traffic at the data link layer.

L2 Announcement Feature Enablement and Configuration:

* Enabled L2 announcements in the Cilium configuration, specifying lease timing parameters to control how frequently Cilium announces service IPs on the network.
* Configured Kubernetes client rate limiting for Cilium to manage API request bursts and prevent overloading the Kubernetes API server.

L2 Announcement Policy Addition:

* Added a new `CiliumL2AnnouncementPolicy` resource (`l2-announcement-policy.yaml`) that matches services with the `network` label, applies to interfaces matching `^br0(\.[\d]+)?`, and enables advertisement of both external and load balancer IPs.