### PR TITLE
fix: bootstrap00: gateway: switch back to loadbalancer

### DIFF
--- a/kubernetes/apps/bootstrap00/ca/service.yaml
+++ b/kubernetes/apps/bootstrap00/ca/service.yaml
@@ -11,34 +11,38 @@ metadata:
     lbipam.cilium.io/ips: "${caMgmtIpv4},${caMgmtIpv6}"
 spec:
   ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
   ports:
     - name: ca-server
       port: 443
       protocol: TCP
       targetPort: 9000
   type: LoadBalancer
+  loadBalancerClass: io.cilium/l2-announcer
   selector:
     app.kubernetes.io/instance: step-certificates
     app.kubernetes.io/name: step-certificates
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: ca-service
-  namespace: smallstep
-  labels:
-    app: ca
-    network: service
-  annotations:
-    lbipam.cilium.io/ips: "${caServiceIpv4},${caServiceIpv6}"
-spec:
-  ipFamilyPolicy: PreferDualStack
-  ports:
-    - name: ca-server
-      port: 443
-      protocol: TCP
-      targetPort: 9000
-  type: LoadBalancer
-  selector:
-    app.kubernetes.io/instance: step-certificates
-    app.kubernetes.io/name: step-certificates
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: ca-service
+#   namespace: smallstep
+#   labels:
+#     app: ca
+#     network: service
+#   annotations:
+#     lbipam.cilium.io/ips: "${caServiceIpv4},${caServiceIpv6}"
+# spec:
+#   ipFamilyPolicy: PreferDualStack
+#   ports:
+#     - name: ca-server
+#       port: 443
+#       protocol: TCP
+#       targetPort: 9000
+#   type: LoadBalancer
+#   selector:
+#     app.kubernetes.io/instance: step-certificates
+#     app.kubernetes.io/name: step-certificates

--- a/kubernetes/apps/bootstrap00/gateway.yaml
+++ b/kubernetes/apps/bootstrap00/gateway.yaml
@@ -1,40 +1,70 @@
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: bootstrap-shared-mgmt
-  namespace: bootstrap
-  annotations:
-    cert-manager.io/cluster-issuer: homelab-internal
-spec:
-  infrastructure:
-    annotations:
-      lbipam.cilium.io/ips: "${bootstrapMgmtIpv4},${bootstrapMgmtIpv6}"
-      lbipam.cilium.io/sharing-key: mgmt-bootstrap
-    labels:
-      network: mgmt
-  gatewayClassName: cilium
-  listeners:
-    - name: http
-      port: 80
-      protocol: HTTP
-      hostname: "*.bootstrap.${mgmtDomainOld}"
-    - name: https
-      protocol: HTTPS
-      port: 443
-      hostname: "*.bootstrap.${mgmtDomainOld}"
-      tls:
-        mode: Terminate
-        certificateRefs:
-          - name: bootstrap-shared-mgmt-wildcard
-    # - name: http-unifi
-    #   port: 8080
-    #   protocol: HTTP
-    #   hostname: "*.bootstrap.${mgmtDomainOld}"
-    # - name: https-unifi
-    #   port: 8443
-    #   protocol: HTTPS
-    #   hostname: "*.bootstrap.${mgmtDomainOld}"
+# ---
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: GatewayClass
+# metadata:
+#   name: internal-bootstrap
+# spec:
+#   controllerName: io.cilium/gateway-controller
+#   description: Internal Cilium GatewayClass for bootstrap
+#   parametersRef:
+#     group: cilium.io
+#     kind: CiliumGatewayClassConfig
+#     name: internal-bootstrap-config
+#     namespace: bootstrap
+# ---
+# apiVersion: cilium.io/v2alpha1
+# kind: CiliumGatewayClassConfig
+# metadata:
+#   name: internal-bootstrap-config
+#   namespace: bootstrap
+# spec:
+#   service:
+#     loadBalancerClass: io.cilium/l2-announcer
+#     ipFamilyPolicy: PreferDualStack
+#     ipFamilies:
+#       - IPv4
+#       - IPv6
+# ---
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: Gateway
+# metadata:
+#   name: bootstrap-shared-mgmt
+#   namespace: bootstrap
+#   annotations:
+#     cert-manager.io/cluster-issuer: homelab-internal
+# spec:
+#   infrastructure:
+#     annotations:
+#       lbipam.cilium.io/ips: "${bootstrapMgmtIpv4},${bootstrapMgmtIpv6}"
+#       lbipam.cilium.io/sharing-key: mgmt-bootstrap
+#     labels:
+#       network: mgmt
+#   gatewayClassName: internal-bootstrap
+#   listeners:
+#     - name: netbootxyzmgmt-http
+#       port: 80
+#       protocol: HTTP
+#       hostname: "*.bootstrap.${mgmtDomainOld}"
+#     - name: netbootxyzmgmt-https
+#       protocol: HTTPS
+#       port: 443
+#       hostname: "*.bootstrap.${mgmtDomainOld}"
+#       tls:
+#         mode: Terminate
+#         certificateRefs:
+#           - name: netbootxyz-bootstrap-mgmt-tls
+#     - name: netbootxyz-assets
+#       port: 80
+#       protocol: HTTP
+#       hostname: "*.bootstrap.${mgmtDomainOld}"
+#     # - name: http-unifi
+#     #   port: 8080
+#     #   protocol: HTTP
+#     #   hostname: "*.bootstrap.${mgmtDomainOld}"
+#     # - name: https-unifi
+#     #   port: 8443
+#     #   protocol: HTTPS
+#     #   hostname: "*.bootstrap.${mgmtDomainOld}"
 ---
 # apiVersion: gateway.networking.k8s.io/v1
 # kind: Gateway
@@ -63,25 +93,26 @@ spec:
 #         mode: Terminate
 #         certificateRefs:
 #           - name: ca-mgmt-wildcard
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: bootstrap-shared-service
-  namespace: bootstrap
-spec:
-  infrastructure:
-    annotations:
-      lbipam.cilium.io/ips: "${bootstrapServiceIpv4},${bootstrapServiceIpv6}"
-      lbipam.cilium.io/sharing-key: service-bootstrap
-    labels:
-      network: service
-  gatewayClassName: cilium
-  listeners:
-    - name: http
-      port: 80
-      protocol: HTTP
----
+# ---
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: Gateway
+# metadata:
+#   name: bootstrap-shared-service
+#   namespace: bootstrap
+# spec:
+#   infrastructure:
+#     annotations:
+#       lbipam.cilium.io/ips: "${bootstrapServiceIpv4},${bootstrapServiceIpv6}"
+#       lbipam.cilium.io/sharing-key: service-bootstrap
+#     labels:
+#       network: service
+#   gatewayClassName: internal-bootstrap
+#   listeners:
+#     - name: netbootxyz-assets
+#       port: 80
+#       protocol: HTTP
+#       hostname: "netbootxyz.bootstrap.${serviceDomainOld}"
+# ---
 # apiVersion: gateway.networking.k8s.io/v1
 # kind: Gateway
 # metadata:
@@ -110,23 +141,23 @@ spec:
 #         certificateRefs:
 #           - name: ca-service-wildcard
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: bootstrap-shared-k8s00
-  namespace: bootstrap
-spec:
-  infrastructure:
-    annotations:
-      lbipam.cilium.io/ips: "${bootstrapK8s00Ipv4},${bootstrapK8s00Ipv6}"
-      lbipam.cilium.io/sharing-key: k8s00-bootstrap
-    labels:
-      network: k8s00
-  gatewayClassName: cilium
-  listeners:
-    - name: http
-      port: 80
-      protocol: HTTP
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: Gateway
+# metadata:
+#   name: bootstrap-shared-k8s00
+#   namespace: bootstrap
+# spec:
+#   infrastructure:
+#     annotations:
+#       lbipam.cilium.io/ips: "${bootstrapK8s00Ipv4},${bootstrapK8s00Ipv6}"
+#       lbipam.cilium.io/sharing-key: k8s00-bootstrap
+#     labels:
+#       network: k8s00
+#   gatewayClassName: cilium
+#   listeners:
+#     - name: http
+#       port: 80
+#       protocol: HTTP
 ---
 # apiVersion: gateway.networking.k8s.io/v1
 # kind: Gateway

--- a/kubernetes/apps/bootstrap00/gateway.yaml
+++ b/kubernetes/apps/bootstrap00/gateway.yaml
@@ -140,7 +140,7 @@
 #         mode: Terminate
 #         certificateRefs:
 #           - name: ca-service-wildcard
----
+# ---
 # apiVersion: gateway.networking.k8s.io/v1
 # kind: Gateway
 # metadata:

--- a/kubernetes/apps/bootstrap00/gateway.yaml
+++ b/kubernetes/apps/bootstrap00/gateway.yaml
@@ -158,7 +158,7 @@
 #     - name: http
 #       port: 80
 #       protocol: HTTP
----
+# ---
 # apiVersion: gateway.networking.k8s.io/v1
 # kind: Gateway
 # metadata:

--- a/kubernetes/apps/bootstrap00/gateway.yaml
+++ b/kubernetes/apps/bootstrap00/gateway.yaml
@@ -65,7 +65,7 @@
 #     #   port: 8443
 #     #   protocol: HTTPS
 #     #   hostname: "*.bootstrap.${mgmtDomainOld}"
----
+# ---
 # apiVersion: gateway.networking.k8s.io/v1
 # kind: Gateway
 # metadata:

--- a/kubernetes/apps/bootstrap00/netbootxyz/http-route.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/http-route.yaml
@@ -49,7 +49,7 @@
 #       sectionName: netbootxyz-assets
 #       port: 80
 #   hostnames:
-#     - "netbootxyz.bootstrap.${mgmtDomainOld}"
+#     - "netbootxyz.bootstrap.${serviceDomainOld}"
 #   rules:
 #     - name: assets
 #       backendRefs:

--- a/kubernetes/apps/bootstrap00/netbootxyz/http-route.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/http-route.yaml
@@ -1,76 +1,95 @@
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: mgmt-admin
-  namespace: bootstrap
-spec:
-  parentRefs:
-    - name: bootstrap-shared-mgmt
-      namespace: bootstrap
-      sectionName: https
-      port: 443
-  hostnames:
-    - "netbootxyzmgmt.bootstrap.${mgmtDomainOld}"
-  rules:
-    - name: https
-      backendRefs:
-        - name: netbootxyz
-          port: 3000
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: mgmt-assets
-  namespace: bootstrap
-spec:
-  parentRefs:
-    - name: bootstrap-shared-mgmt
-      namespace: bootstrap
-      sectionName: http
-      port: 80
-  hostnames:
-    - "netbootxyz.bootstrap.${mgmtDomainOld}"
-  rules:
-    - name: http
-      backendRefs:
-        - name: netbootxyz
-          port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: service-assets
-  namespace: bootstrap
-spec:
-  parentRefs:
-    - name: bootstrap-shared-service
-      namespace: bootstrap
-      sectionName: http
-      port: 80
-  hostnames:
-    - "netbootxyz.bootstrap.${serviceDomainOld}"
-  rules:
-    - name: http
-      backendRefs:
-        - name: netbootxyz
-          port: 80
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: k8s00-assets
-  namespace: bootstrap
-spec:
-  parentRefs:
-    - name: bootstrap-shared-k8s00
-      namespace: bootstrap
-      sectionName: http
-      port: 80
-  hostnames:
-    - "netbootxyz.bootstrap.${k8s00DomainOld}"
-  rules:
-    - name: https
-      backendRefs:
-        - name: netbootxyz
-          port: 80
+# ---
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: HTTPRoute
+# metadata:
+#   name: mgmt-admin
+#   namespace: bootstrap
+# spec:
+#   parentRefs:
+#     - name: bootstrap-shared-mgmt
+#       namespace: bootstrap
+#       sectionName: netbootxyzmgmt-https
+#       port: 443
+#   hostnames:
+#     - "netbootxyzmgmt.bootstrap.${mgmtDomainOld}"
+#   rules:
+#     - name: admin
+#       backendRefs:
+#         - name: netbootxyz
+#           port: 3000
+# ---
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: HTTPRoute
+# metadata:
+#   name: mgmt-assets
+#   namespace: bootstrap
+# spec:
+#   parentRefs:
+#     - name: bootstrap-shared-mgmt
+#       namespace: bootstrap
+#       sectionName: netbootxyz-assets
+#       port: 80
+#   hostnames:
+#     - "netbootxyz.bootstrap.${mgmtDomainOld}"
+#   rules:
+#     - name: assets
+#       backendRefs:
+#         - name: netbootxyz
+#           port: 80
+# ---
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: HTTPRoute
+# metadata:
+#   name: mgmt-assets
+#   namespace: bootstrap
+# spec:
+#   parentRefs:
+#     - name: bootstrap-shared-service
+#       namespace: bootstrap
+#       sectionName: netbootxyz-assets
+#       port: 80
+#   hostnames:
+#     - "netbootxyz.bootstrap.${mgmtDomainOld}"
+#   rules:
+#     - name: assets
+#       backendRefs:
+#         - name: netbootxyz
+#           port: 80
+# ---
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: HTTPRoute
+# metadata:
+#   name: service-assets
+#   namespace: bootstrap
+# spec:
+#   parentRefs:
+#     - name: bootstrap-shared-service
+#       namespace: bootstrap
+#       sectionName: netbootxyz-assets
+#       port: 80
+#   hostnames:
+#     # - "netbootxyz.bootstrap.${serviceDomainOld}"
+#   rules:
+#     - name: assets
+#       backendRefs:
+#         - name: netbootxyz
+#           port: 80
+# ---
+# apiVersion: gateway.networking.k8s.io/v1
+# kind: HTTPRoute
+# metadata:
+#   name: k8s00-assets
+#   namespace: bootstrap
+# spec:
+#   parentRefs:
+#     - name: bootstrap-shared-k8s00
+#       namespace: bootstrap
+#       sectionName: http
+#       port: 80
+#   hostnames:
+#     - "netbootxyz.bootstrap.${k8s00DomainOld}"
+#   rules:
+#     - name: assets
+#       backendRefs:
+#         - name: netbootxyz
+#           port: 80

--- a/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   ipFamilyPolicy: PreferDualStack
   ports:
-    - name: web
+    - name: tftp
       port: 69
       protocol: UDP
       targetPort: 69
@@ -62,7 +62,7 @@ spec:
 # spec:
 #   ipFamilyPolicy: PreferDualStack
 #   ports:
-#     - name: web
+#     - name: tftp
 #       port: 69
 #       protocol: UDP
 #       targetPort: 69
@@ -84,7 +84,7 @@ spec:
 # spec:
 #   ipFamilyPolicy: PreferDualStack
 #   ports:
-#     - name: web
+#     - name: tftp
 #       port: 69
 #       protocol: UDP
 #       targetPort: 69

--- a/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
@@ -22,7 +22,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: netbootxyz-tftp-mgmt
+  name: netbootxyz-mgmt
   namespace: bootstrap
   labels:
     app: netbootxyz
@@ -37,50 +37,57 @@ spec:
       port: 69
       protocol: UDP
       targetPort: 69
+    - name: assets
+      port: 80
+      targetPort: 80
+    - name: admin
+      port: 3000
+      targetPort: 3000
   type: LoadBalancer
+  loadBalancerClass: io.cilium/l2-announcer
   selector:
     app: netbootxyz
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: netbootxyz-tftp-service
-  namespace: bootstrap
-  labels:
-    app: netbootxyz
-    network: service
-  annotations:
-    lbipam.cilium.io/ips: "${bootstrapServiceIpv4},${bootstrapServiceIpv6}"
-    lbipam.cilium.io/sharing-key: service-bootstrap
-spec:
-  ipFamilyPolicy: PreferDualStack
-  ports:
-    - name: web
-      port: 69
-      protocol: UDP
-      targetPort: 69
-  type: LoadBalancer
-  selector:
-    app: netbootxyz
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: netbootxyz-tftp-k8s00
-  namespace: bootstrap
-  labels:
-    app: netbootxyz
-    network: k8s00
-  annotations:
-    lbipam.cilium.io/ips: "${bootstrapK8s00Ipv4},${bootstrapK8s00Ipv6}"
-    lbipam.cilium.io/sharing-key: k8s00-bootstrap
-spec:
-  ipFamilyPolicy: PreferDualStack
-  ports:
-    - name: web
-      port: 69
-      protocol: UDP
-      targetPort: 69
-  type: LoadBalancer
-  selector:
-    app: netbootxyz
+# ---
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: netbootxyz-tftp-service
+#   namespace: bootstrap
+#   labels:
+#     app: netbootxyz
+#     network: service
+#   annotations:
+#     lbipam.cilium.io/ips: "${bootstrapServiceIpv4},${bootstrapServiceIpv6}"
+#     lbipam.cilium.io/sharing-key: service-bootstrap
+# spec:
+#   ipFamilyPolicy: PreferDualStack
+#   ports:
+#     - name: web
+#       port: 69
+#       protocol: UDP
+#       targetPort: 69
+#   type: LoadBalancer
+#   selector:
+#     app: netbootxyz
+# ---
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: netbootxyz-tftp-k8s00
+#   namespace: bootstrap
+#   labels:
+#     app: netbootxyz
+#     network: k8s00
+#   annotations:
+#     lbipam.cilium.io/ips: "${bootstrapK8s00Ipv4},${bootstrapK8s00Ipv6}"
+#     lbipam.cilium.io/sharing-key: k8s00-bootstrap
+# spec:
+#   ipFamilyPolicy: PreferDualStack
+#   ports:
+#     - name: web
+#       port: 69
+#       protocol: UDP
+#       targetPort: 69
+#   type: LoadBalancer
+#   selector:
+#     app: netbootxyz

--- a/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
@@ -35,7 +35,7 @@ spec:
   ipFamilies:
     - IPv4
     - IPv6
-  ports: 
+  ports:
     - name: tftp
       port: 69
       protocol: UDP

--- a/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
@@ -32,7 +32,10 @@ metadata:
     lbipam.cilium.io/sharing-key: mgmt-bootstrap
 spec:
   ipFamilyPolicy: PreferDualStack
-  ports:
+  ipFamilies:
+    - IPv4
+    - IPv6
+  ports: 
     - name: tftp
       port: 69
       protocol: UDP

--- a/kubernetes/apps/bootstrap00/unifi/http-route.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/http-route.yaml
@@ -9,7 +9,7 @@
 #     - name: bootstrap-shared-mgmt
 #       namespace: bootstrap
 #       sectionName: https
-#       port: 8443
+#       port: 443
 #   hostnames:
 #     - "unifi.bootstrap.mgmt.${homeDomainOld}"
 #   rules:

--- a/kubernetes/apps/bootstrap00/unifi/services.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/services.yaml
@@ -35,6 +35,9 @@ metadata:
     lbipam.cilium.io/sharing-key: mgmt-bootstrap
 spec:
   ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
   ports:
     - name: discovery
       port: 10001
@@ -56,6 +59,8 @@ spec:
       protocol: TCP
       targetPort: 8443
   type: LoadBalancer
+  loadBalancerClass: io.cilium/l2-announcer
+  # loadBalancerClass: io.cilium/bgp-control-plane
   selector:
     app: unifi-network-application
 ---


### PR DESCRIPTION
This pull request makes several updates to the Kubernetes bootstrap configuration, primarily to improve load balancer configuration, update service definitions, and refactor Gateway and HTTPRoute resources for better alignment with Cilium networking and multi-network support. The changes also consolidate and modernize service and route definitions for `netbootxyz` and related resources.

**Key changes include:**

### Load Balancer and Service Configuration

* Added `loadBalancerClass: io.cilium/l2-announcer` and explicit `ipFamilies` (IPv4 and IPv6) to several Service resources (`ca/service.yaml`, `unifi/services.yaml`, and `netbootxyz/services.yaml`) to improve dual-stack support and leverage Cilium L2 load balancing. [[1]](diffhunk://#diff-1d64e8c8c7222ea868cd3b221966bfd7241b56d1cfb36a5ab55829b15cda8699R14-R48) [[2]](diffhunk://#diff-b7c266d042c1217351f5e61a21f7abec87d81032faa4e1feee695eb4e56ec88dR38-R40) [[3]](diffhunk://#diff-b7c266d042c1217351f5e61a21f7abec87d81032faa4e1feee695eb4e56ec88dR62-R63) [[4]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351R40-R93)

* Consolidated and renamed `netbootxyz` Service resources, combining multiple TFTP and web service definitions into a single `netbootxyz-mgmt` Service with multiple ports, and commented out/deprecated the old multi-network Service resources. [[1]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351L25-R25) [[2]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351R40-R93)

### Gateway and HTTPRoute Refactoring

* Refactored Gateway resources to introduce a custom `GatewayClass` (`internal-bootstrap`) and associated `CiliumGatewayClassConfig`, switching Gateway definitions to use this class and updating listener sections to be more descriptive and aligned with new service ports. [[1]](diffhunk://#diff-c1e8d642698b09f53bad4c4da714e105fb5052b1cd80b8881d4c99ab3187bb0fL1-R67) [[2]](diffhunk://#diff-c1e8d642698b09f53bad4c4da714e105fb5052b1cd80b8881d4c99ab3187bb0fL66-R115) [[3]](diffhunk://#diff-c1e8d642698b09f53bad4c4da714e105fb5052b1cd80b8881d4c99ab3187bb0fL113-R160)

* Updated all relevant HTTPRoute resources for `netbootxyz` to match the new Gateway listener names and service port structure, ensuring correct routing and backend references. Old route definitions are commented out and replaced with new ones.

### Minor Fixes

* Fixed the port reference for Unifi HTTPRoute from 8443 to 443 to match the updated Gateway listener configuration.