### PR TITLE
feat: bootstrap00: services: add service and k8s00 network

### DIFF
--- a/kubernetes/apps/bootstrap00/ca/service.yaml
+++ b/kubernetes/apps/bootstrap00/ca/service.yaml
@@ -25,24 +25,28 @@ spec:
     app.kubernetes.io/instance: step-certificates
     app.kubernetes.io/name: step-certificates
 ---
-# apiVersion: v1
-# kind: Service
-# metadata:
-#   name: ca-service
-#   namespace: smallstep
-#   labels:
-#     app: ca
-#     network: service
-#   annotations:
-#     lbipam.cilium.io/ips: "${caServiceIpv4},${caServiceIpv6}"
-# spec:
-#   ipFamilyPolicy: PreferDualStack
-#   ports:
-#     - name: ca-server
-#       port: 443
-#       protocol: TCP
-#       targetPort: 9000
-#   type: LoadBalancer
-#   selector:
-#     app.kubernetes.io/instance: step-certificates
-#     app.kubernetes.io/name: step-certificates
+apiVersion: v1
+kind: Service
+metadata:
+  name: ca-service
+  namespace: smallstep
+  labels:
+    app: ca
+    network: service
+  annotations:
+    lbipam.cilium.io/ips: "${caServiceIpv4},${caServiceIpv6}"
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+  ports:
+    - name: ca-server
+      port: 443
+      protocol: TCP
+      targetPort: 9000
+  type: LoadBalancer
+  loadBalancerClass: io.cilium/bgp-control-plane
+  selector:
+    app.kubernetes.io/instance: step-certificates
+    app.kubernetes.io/name: step-certificates

--- a/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
@@ -50,47 +50,55 @@ spec:
   loadBalancerClass: io.cilium/l2-announcer
   selector:
     app: netbootxyz
-# ---
-# apiVersion: v1
-# kind: Service
-# metadata:
-#   name: netbootxyz-tftp-service
-#   namespace: bootstrap
-#   labels:
-#     app: netbootxyz
-#     network: service
-#   annotations:
-#     lbipam.cilium.io/ips: "${bootstrapServiceIpv4},${bootstrapServiceIpv6}"
-#     lbipam.cilium.io/sharing-key: service-bootstrap
-# spec:
-#   ipFamilyPolicy: PreferDualStack
-#   ports:
-#     - name: tftp
-#       port: 69
-#       protocol: UDP
-#       targetPort: 69
-#   type: LoadBalancer
-#   selector:
-#     app: netbootxyz
-# ---
-# apiVersion: v1
-# kind: Service
-# metadata:
-#   name: netbootxyz-tftp-k8s00
-#   namespace: bootstrap
-#   labels:
-#     app: netbootxyz
-#     network: k8s00
-#   annotations:
-#     lbipam.cilium.io/ips: "${bootstrapK8s00Ipv4},${bootstrapK8s00Ipv6}"
-#     lbipam.cilium.io/sharing-key: k8s00-bootstrap
-# spec:
-#   ipFamilyPolicy: PreferDualStack
-#   ports:
-#     - name: tftp
-#       port: 69
-#       protocol: UDP
-#       targetPort: 69
-#   type: LoadBalancer
-#   selector:
-#     app: netbootxyz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: netbootxyz-tftp-service
+  namespace: bootstrap
+  labels:
+    app: netbootxyz
+    network: service
+  annotations:
+    lbipam.cilium.io/ips: "${bootstrapServiceIpv4},${bootstrapServiceIpv6}"
+    lbipam.cilium.io/sharing-key: service-bootstrap
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ports:
+    - name: tftp
+      port: 69
+      protocol: UDP
+      targetPort: 69
+    - name: assets
+      port: 80
+      targetPort: 80
+  type: LoadBalancer
+  loadBalancerClass: io.cilium/bgp-control-plane
+  selector:
+    app: netbootxyz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: netbootxyz-tftp-k8s00
+  namespace: bootstrap
+  labels:
+    app: netbootxyz
+    network: k8s00
+  annotations:
+    lbipam.cilium.io/ips: "${bootstrapK8s00Ipv4},${bootstrapK8s00Ipv6}"
+    lbipam.cilium.io/sharing-key: k8s00-bootstrap
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ports:
+    - name: tftp
+      port: 69
+      protocol: UDP
+      targetPort: 69
+    - name: assets
+      port: 80
+      targetPort: 80
+  type: LoadBalancer
+  loadBalancerClass: io.cilium/bgp-control-plane
+  selector:
+    app: netbootxyz


### PR DESCRIPTION
This pull request updates the Kubernetes service definitions for the `step-certificates` and `netbootxyz` applications to enable dual-stack (IPv4/IPv6) support and to use the Cilium BGP control plane for load balancing. It also adds new ports to the `netbootxyz` services and uncomments previously commented-out service resources, making them active.

Networking improvements and dual-stack support:

* Updated the `ca-service` and `netbootxyz` service definitions to explicitly support both IPv4 and IPv6 by setting `ipFamilyPolicy: PreferDualStack` and specifying `ipFamilies` where appropriate. [[1]](diffhunk://#diff-1d64e8c8c7222ea868cd3b221966bfd7241b56d1cfb36a5ab55829b15cda8699L28-R52) [[2]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351L53-R104)
* Switched the load balancer implementation for these services to use `loadBalancerClass: io.cilium/bgp-control-plane` for BGP-based load balancing. [[1]](diffhunk://#diff-1d64e8c8c7222ea868cd3b221966bfd7241b56d1cfb36a5ab55829b15cda8699L28-R52) [[2]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351L53-R104)

Service resource enhancements:

* Uncommented and activated previously commented-out Kubernetes `Service` resources for `ca-service`, `netbootxyz-tftp-service`, and `netbootxyz-tftp-k8s00`, making them part of the deployment. [[1]](diffhunk://#diff-1d64e8c8c7222ea868cd3b221966bfd7241b56d1cfb36a5ab55829b15cda8699L28-R52) [[2]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351L53-R104)
* Added an additional `assets` port (port 80) to the `netbootxyz-tftp-service` and `netbootxyz-tftp-k8s00` services, allowing these services to expose both TFTP (port 69) and HTTP (port 80) endpoints.