### PR TITLE
feat: bootstrap00: add ingress-nginx

### DIFF
--- a/kubernetes/infrastructure/bootstrap00/ingress-nginx.yaml
+++ b/kubernetes/infrastructure/bootstrap00/ingress-nginx.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: flux-system
+spec:
+  interval: 1440m
+  url: https://kubernetes.github.io/ingress-nginx
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+spec:
+  interval: 30m
+  install:
+    createNamespace: true
+  chart:
+    spec:
+      chart: ingress-nginx
+      version: ">= 4.15.1 < 4.16.0"
+      sourceRef:
+        kind: HelmRepository
+        name: ingress-nginx
+        namespace: flux-system
+      interval: 1m
+  values:
+    controller:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+        prometheusRule:
+          enabled: true

--- a/kubernetes/infrastructure/bootstrap00/issuers.yaml
+++ b/kubernetes/infrastructure/bootstrap00/issuers.yaml
@@ -29,3 +29,6 @@ spec:
                 namespace: smallstep
               # - name: pihole-shared
               #   namespace: pihole
+      - http01:
+          ingress:
+            ingressClassName: nginx


### PR DESCRIPTION
This pull request introduces the configuration for deploying the `ingress-nginx` controller using Flux and Helm, and updates the issuer configuration to support HTTP-01 challenges via the NGINX ingress. The main focus is on automating the setup of ingress and enabling metrics for monitoring.

**Ingress NGINX deployment and monitoring:**
- Added `kubernetes/infrastructure/bootstrap00/ingress-nginx.yaml` to define the `ingress-nginx` namespace, Helm repository, and Helm release for the NGINX ingress controller, including configuration for metrics and Prometheus integration.

**Certificate issuer configuration:**
- Updated `kubernetes/infrastructure/bootstrap00/issuers.yaml` to enable HTTP-01 challenge support by specifying the `nginx` ingress class in the issuer configuration.