### PR TITLE
fix: bootstrap00: ingress-nginx: add missing configuration to obtain IPs

### DIFF
--- a/kubernetes/infrastructure/bootstrap00/ingress-nginx.yaml
+++ b/kubernetes/infrastructure/bootstrap00/ingress-nginx.yaml
@@ -34,8 +34,13 @@ spec:
   values:
     controller:
       metrics:
-        enabled: true
-        serviceMonitor:
-          enabled: true
-        prometheusRule:
-          enabled: true
+        enabled: false
+      service:
+        # annotations:
+        ipFamilies:
+          - IPv4
+          - IPv6
+        ipFamilyPolicy: PreferDualStack
+        labels:
+          network: mgmt
+        loadBalancerClass: io.cilium/bgp-control-plane


### PR DESCRIPTION
This pull request updates the configuration for the NGINX ingress controller in the Kubernetes bootstrap manifest. The main focus is on disabling metrics and customizing the service specification to support dual-stack networking and integrate with Cilium's BGP control plane.

Key configuration changes:

**Metrics and Monitoring:**
* Disabled metrics collection and monitoring features by setting `metrics.enabled` to `false` and removing related `serviceMonitor` and `prometheusRule` settings.

**Service Customization:**
* Added service configuration to support both IPv4 and IPv6 (`ipFamilies`), set the IP family policy to `PreferDualStack`, labeled the service with `network: mgmt`, and specified the `loadBalancerClass` as `io.cilium/bgp-control-plane` for integration with Cilium's BGP control plane.