### PR TITLE
fix: bootstrap00: external-dns: missing variable

### DIFF
--- a/kubernetes/infrastructure/bootstrap00/external-dns.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns.yaml
@@ -42,7 +42,7 @@ spec:
             # Switch to pihole V6 API
             - --pihole-api-version=6
             # Change this to the actual address of your Pi-hole web server
-            - --pihole-server=${pihole_url}
+            - --pihole-server=${piholeUrl}
             - --pihole-tls-skip-verify
         - op: add
           path: /spec/template/spec/containers/0/envFrom


### PR DESCRIPTION
This pull request makes a small update to the `external-dns.yaml` configuration. The change updates the environment variable reference for the Pi-hole server address to use `piholeUrl` instead of `pihole_url`.