### PR TITLE
fix: bootstrap00: external-dns: wrong url

### DIFF
--- a/kubernetes/clusters/bootstrap00/global.values.sops.yaml
+++ b/kubernetes/clusters/bootstrap00/global.values.sops.yaml
@@ -24,7 +24,9 @@ stringData:
   caMgmtIpv6: ENC[AES256_GCM,data:zLTtaBmpnVC5PyN6i9S38zUEmSv5QGA=,iv:0vEmH1PV6zZFPaDtQ5VHJtGSvL5/qo7FmyPSIDDsRgQ=,tag:uumpgZ6Dxv+0dRpa0wb6QA==,type:str]
   caServiceIpv4: ENC[AES256_GCM,data:Nxebg/k0lUZNDXQTLw==,iv:WcG81uUhQZmSFTBH4zfN+9dHZP3pmMR1we8oC2diLJ0=,tag:pVXWO3bsLKVZqjqOwH5tZQ==,type:str]
   caServiceIpv6: ENC[AES256_GCM,data:v8sBWHbA2oeiYH+VuGmsyIXPSTf6QuM=,iv:8uY/dljhJBFXqMpLCFNgGDlAfNaFrboSiXnsk1hy3Ww=,tag:261oDenmheScHsIGXNXtzA==,type:str]
-  piholeUrl: ENC[AES256_GCM,data:TLIUR6oot54Z7Bb5LUg34Zmtyu0SWKu/N8BdddKtQVS7bIiouizJiE+64fXMbA==,iv:hMXkxSU+aRvtPhc3A1y49n6/uUKvUbXzxf8z8Vg56VM=,tag:Nt6Yda+PPaJa8ra/c20Q8Q==,type:str]
+  piholeUrlMgmt: ENC[AES256_GCM,data:N/iorthdXv/zCm7aWfDwGJeItTpO6EECFGInzvXh5f+UlEBHmcVWolJy8og=,iv:Y7dfsT3l9SfbhiaEJdIcCRbarqxC/KOezjGRuxBLMCY=,tag:ZaZ5Yv6vmf2KsDm3S9CaqA==,type:str]
+  piholeUrlMgmtBootstrap00: ENC[AES256_GCM,data:VIe7K8xckEGAgOSK1kWqDfjjnOabKg89tQijPEWcb1nAaDrtgI2Wjp/zjcpN0a/Xqw==,iv:c1UfUlD/Uau43X3tvbS9owUbl+tUc/m74kdYEKmjssY=,tag:N1dkjQyu76LYWAkcaOeGEQ==,type:str]
+  piholeUrlMgmtK8s00: ENC[AES256_GCM,data:vBTyBpVbG1eMu20Zr9/Yi9Irs+1tyQPQIJZ9zZUC9DSzCeX1tT/SbT68pA==,iv:Ut1seW85ri1ecvopE2GNAZjswcS7NoqESEBl/JnkH8Y=,tag:rmFePYUD9pV/3E0XddyMIA==,type:str]
 sops:
   age:
     - enc: |
@@ -37,6 +39,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-07T16:24:00Z"
-  mac: ENC[AES256_GCM,data:Hb86Jcx6lcYGhdZkfIJaiaoEUU/XFu8pAmdU3JsZup8I2kZdFfb84LqENTEegN0GvHoMs8yqeqp/i2hGs/e5uXZFmULNmtfqMTcQS7gpmdpiPOgib0DmR9UQ/BeXZighG6lpvyurHvTnkDZAgEqEk9vDtDWIU56slPIdN02dyfU=,iv:IxdnzMk8Rc5M58yGyEUlIO37iiACK6r1/loPoNCFSnY=,tag:3rS3vHTtK64ltEiIA+8Ipg==,type:str]
+  lastmodified: "2026-06-21T13:57:31Z"
+  mac: ENC[AES256_GCM,data:cfmTi3Wtz7M8DVwGa5prdtm/w108XivVhbLV6yyP+WtkqL6v8PEOr+K8oovbzRU97hG7E5BsmP7ttOmrVczGgpTumYjSYz1+VBtdMmD1W4yDswVZhPQndW7FvdGWI+/4t+lm1mZKwQWUHSX0YShgrrz1pzco0k0nMhKA9Pk/Wjc=,iv:7dn0C7S1iT49HXZ9NAr27XdIaE0N99vPeOigQiFrFtA=,tag:CZYreCHD8bA6Q/tuBrKN1g==,type:str]
   version: 3.13.1

--- a/kubernetes/infrastructure/bootstrap00/external-dns.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns.yaml
@@ -42,7 +42,7 @@ spec:
             # Switch to pihole V6 API
             - --pihole-api-version=6
             # Change this to the actual address of your Pi-hole web server
-            - --pihole-server=${piholeUrl}
+            - --pihole-server=${piholeUrlMgmt}
             - --pihole-tls-skip-verify
         - op: add
           path: /spec/template/spec/containers/0/envFrom


### PR DESCRIPTION
This pull request updates encrypted configuration values in the `global.values.sops.yaml` file for the `bootstrap00` Kubernetes cluster. The main change is the replacement of the `piholeUrl` secret with new, more specific secrets for Pi-hole management endpoints, along with an update to the SOPS metadata.

**Pi-hole URL Management Updates:**
- Replaced the single `piholeUrl` secret with three new secrets: `piholeUrlMgmt`, `piholeUrlMgmtBootstrap00`, and `piholeUrlMgmtK8s00`, to provide more granular management of Pi-hole endpoints.

**SOPS Metadata Update:**
- Updated the `lastmodified` timestamp and `mac` (message authentication code) in the SOPS section to reflect the new encrypted values.