### PR TITLE
fix: bootstrap00: cert-manager: switch the issuers solvers order

### DIFF
--- a/kubernetes/infrastructure/bootstrap00/issuers.yaml
+++ b/kubernetes/infrastructure/bootstrap00/issuers.yaml
@@ -19,6 +19,9 @@ spec:
     # Add a single challenge solver, HTTP01 using nginx
     solvers:
       - http01:
+          ingress:
+            ingressClassName: nginx
+      - http01:
           gatewayHTTPRoute:
             parentRefs:
               - name: bootstrap-shared-mgmt
@@ -29,6 +32,3 @@ spec:
                 namespace: smallstep
               # - name: pihole-shared
               #   namespace: pihole
-      - http01:
-          ingress:
-            ingressClassName: nginx


### PR DESCRIPTION
This pull request updates the HTTP01 challenge solvers configuration in the `issuers.yaml` file to streamline how the nginx ingress solver is defined. The main change is reordering and consolidating the nginx ingress solver block to avoid redundancy and improve clarity.

Improvements to HTTP01 solver configuration:

* Moved the nginx ingress-based HTTP01 solver to the top of the `solvers` list for better visibility and removed the duplicate definition further down. (`kubernetes/infrastructure/bootstrap00/issuers.yaml`) [[1]](diffhunk://#diff-06477a78327ce9e68d422ad4722ed65575cfa8f28af2ff7cd30ef0d4bc9e3bc1R21-R23) [[2]](diffhunk://#diff-06477a78327ce9e68d422ad4722ed65575cfa8f28af2ff7cd30ef0d4bc9e3bc1L32-L34)