### PR TITLE
fix: bootstrap00: cert-manager: comment unneeded solver

### DIFF
--- a/kubernetes/infrastructure/bootstrap00/issuers.yaml
+++ b/kubernetes/infrastructure/bootstrap00/issuers.yaml
@@ -21,14 +21,14 @@ spec:
       - http01:
           ingress:
             ingressClassName: nginx
-      - http01:
-          gatewayHTTPRoute:
-            parentRefs:
-              - name: bootstrap-shared-mgmt
-                namespace: bootstrap
-              - name: ca-mgmt
-                namespace: smallstep
-              - name: ca-service
-                namespace: smallstep
-              # - name: pihole-shared
-              #   namespace: pihole
+      # - http01:
+      #     gatewayHTTPRoute:
+      #       parentRefs:
+      #         - name: bootstrap-shared-mgmt
+      #           namespace: bootstrap
+      #         - name: ca-mgmt
+      #           namespace: smallstep
+      #         - name: ca-service
+      #           namespace: smallstep
+      #         # - name: pihole-shared
+      #         #   namespace: pihole


### PR DESCRIPTION
This pull request makes a minor change to the `kubernetes/infrastructure/bootstrap00/issuers.yaml` file by commenting out the `gatewayHTTPRoute` configuration under the `http01` section. This effectively disables the use of `gatewayHTTPRoute` for HTTP-01 challenges while keeping the configuration available for future reference.