### PR TITLE
feat: bootstrap00: ingress-nginx: setup ingresses

### DIFF
--- a/kubernetes/apps/bootstrap00/netbootxyz/ingress.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/ingress.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: homelab-internal
+  name: netbootxyz-ingress
+  namespace: bootstrap
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: "netbootxyzmgmt.bootstrap.${mgmtDomainOld}"
+      http:
+        paths:
+          - backend:
+              service:
+                name: netbootxyz
+                port:
+                  number: 3000
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - "netbootxyzmgmt.bootstrap.${mgmtDomainOld}"
+      secretName: "netbootxyzmgmt.bootstrap.${mgmtDomainOld}-tls"

--- a/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
+++ b/kubernetes/apps/bootstrap00/netbootxyz/services.yaml
@@ -43,9 +43,6 @@ spec:
     - name: assets
       port: 80
       targetPort: 80
-    - name: admin
-      port: 3000
-      targetPort: 3000
   type: LoadBalancer
   loadBalancerClass: io.cilium/l2-announcer
   selector:
@@ -54,7 +51,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: netbootxyz-tftp-service
+  name: netbootxyz-service
   namespace: bootstrap
   labels:
     app: netbootxyz
@@ -80,7 +77,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: netbootxyz-tftp-k8s00
+  name: netbootxyz-k8s00
   namespace: bootstrap
   labels:
     app: netbootxyz

--- a/kubernetes/apps/bootstrap00/unifi/ingress.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/ingress.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: homelab-internal
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+  name: unifimgmt-ingress
+  namespace: bootstrap
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: "unifimgmt.bootstrap.${mgmtDomainOld}"
+      http:
+        paths:
+          - backend:
+              service:
+                name: unifi
+                port:
+                  number: 8443
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - "unifimgmt.bootstrap.${mgmtDomainOld}"
+      secretName: "unifimgmt.bootstrap.${mgmtDomainOld}-tls"

--- a/kubernetes/apps/bootstrap00/unifi/services.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/services.yaml
@@ -15,9 +15,6 @@ spec:
     - name: admin-https
       port: 8443
       targetPort: 8443
-    - name: admin-http
-      port: 8880
-      targetPort: 8880
   selector:
     app: unifi-network-application
   type: ClusterIP
@@ -54,10 +51,6 @@ spec:
     - name: device-comm
       port: 8080
       targetPort: 8080
-    - name: admin-https
-      port: 8443
-      protocol: TCP
-      targetPort: 8443
   type: LoadBalancer
   loadBalancerClass: io.cilium/l2-announcer
   # loadBalancerClass: io.cilium/bgp-control-plane

--- a/kubernetes/apps/bootstrap00/unifi/unifi-network-application.yaml
+++ b/kubernetes/apps/bootstrap00/unifi/unifi-network-application.yaml
@@ -57,9 +57,6 @@ spec:
             - containerPort: 8443
               name: admin-https
               protocol: TCP
-            - containerPort: 8880
-              name: admin-http
-              protocol: TCP
           volumeMounts:
             - name: config
               mountPath: /config

--- a/kubernetes/clusters/bootstrap00/global.values.sops.yaml
+++ b/kubernetes/clusters/bootstrap00/global.values.sops.yaml
@@ -24,6 +24,8 @@ stringData:
   caMgmtIpv6: ENC[AES256_GCM,data:zLTtaBmpnVC5PyN6i9S38zUEmSv5QGA=,iv:0vEmH1PV6zZFPaDtQ5VHJtGSvL5/qo7FmyPSIDDsRgQ=,tag:uumpgZ6Dxv+0dRpa0wb6QA==,type:str]
   caServiceIpv4: ENC[AES256_GCM,data:Nxebg/k0lUZNDXQTLw==,iv:WcG81uUhQZmSFTBH4zfN+9dHZP3pmMR1we8oC2diLJ0=,tag:pVXWO3bsLKVZqjqOwH5tZQ==,type:str]
   caServiceIpv6: ENC[AES256_GCM,data:v8sBWHbA2oeiYH+VuGmsyIXPSTf6QuM=,iv:8uY/dljhJBFXqMpLCFNgGDlAfNaFrboSiXnsk1hy3Ww=,tag:261oDenmheScHsIGXNXtzA==,type:str]
+  ingressMgmtIpv4: ENC[AES256_GCM,data:oqTAgXc7UjhaTNA=,iv:ASdTCggZR5eY7GmyfXb5kDDcRNbhKBfowGVCPPMX4Io=,tag:2jKUDi9jc6K6NO+hiumfbQ==,type:str]
+  ingressMgmtIpv6: ENC[AES256_GCM,data:Mov6U8XW8QZ+06yp8E2GJq+AclIcIw==,iv:euM/iPdAh4lCUYuOxbT/CDcqa3+YO9KLtZx6S5Wmatg=,tag:DCO0PN9J2+BwHXYJFnvDVg==,type:str]
   piholeUrlMgmt: ENC[AES256_GCM,data:N/iorthdXv/zCm7aWfDwGJeItTpO6EECFGInzvXh5f+UlEBHmcVWolJy8og=,iv:Y7dfsT3l9SfbhiaEJdIcCRbarqxC/KOezjGRuxBLMCY=,tag:ZaZ5Yv6vmf2KsDm3S9CaqA==,type:str]
   piholeUrlMgmtBootstrap00: ENC[AES256_GCM,data:VIe7K8xckEGAgOSK1kWqDfjjnOabKg89tQijPEWcb1nAaDrtgI2Wjp/zjcpN0a/Xqw==,iv:c1UfUlD/Uau43X3tvbS9owUbl+tUc/m74kdYEKmjssY=,tag:N1dkjQyu76LYWAkcaOeGEQ==,type:str]
   piholeUrlMgmtK8s00: ENC[AES256_GCM,data:vBTyBpVbG1eMu20Zr9/Yi9Irs+1tyQPQIJZ9zZUC9DSzCeX1tT/SbT68pA==,iv:Ut1seW85ri1ecvopE2GNAZjswcS7NoqESEBl/JnkH8Y=,tag:rmFePYUD9pV/3E0XddyMIA==,type:str]
@@ -39,6 +41,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-21T13:57:31Z"
-  mac: ENC[AES256_GCM,data:cfmTi3Wtz7M8DVwGa5prdtm/w108XivVhbLV6yyP+WtkqL6v8PEOr+K8oovbzRU97hG7E5BsmP7ttOmrVczGgpTumYjSYz1+VBtdMmD1W4yDswVZhPQndW7FvdGWI+/4t+lm1mZKwQWUHSX0YShgrrz1pzco0k0nMhKA9Pk/Wjc=,iv:7dn0C7S1iT49HXZ9NAr27XdIaE0N99vPeOigQiFrFtA=,tag:CZYreCHD8bA6Q/tuBrKN1g==,type:str]
+  lastmodified: "2026-06-21T22:44:25Z"
+  mac: ENC[AES256_GCM,data:HCrMdA+hu3Y1suOXexCN8Q6xlbmRqWHsTKzTwZVX5ZX0imlOZF9yJg+ATeTxXBCY8QqSdauWPuK24vQIYoNerVJpP90QufXXZdLJWMQBXbEwPPiJPrXjyGU0eZXQs0InboHgw1m2pWRrKQ+4HY1ZwJFkhFPJmS+4j53o05d/OpM=,iv:6Y+V9Y8rP/lny1ZeIwsVlKIma5uXagBiAPZsD3L6hKs=,tag:YkZh/bJh+3rPxmbOwnvUsg==,type:str]
   version: 3.13.1

--- a/kubernetes/infrastructure/bootstrap00/ingress-nginx.yaml
+++ b/kubernetes/infrastructure/bootstrap00/ingress-nginx.yaml
@@ -37,7 +37,7 @@ spec:
         enabled: false
       service:
         annotations:
-          lbipam.cilium.io/ips: "${ingressMgmtIpv4},${ingressMgmtIpv4}"
+          lbipam.cilium.io/ips: "${ingressMgmtIpv4},${ingressMgmtIpv6}"
         ipFamilies:
           - IPv4
           - IPv6

--- a/kubernetes/infrastructure/bootstrap00/ingress-nginx.yaml
+++ b/kubernetes/infrastructure/bootstrap00/ingress-nginx.yaml
@@ -36,7 +36,8 @@ spec:
       metrics:
         enabled: false
       service:
-        # annotations:
+        annotations:
+          lbipam.cilium.io/ips: "${ingressMgmtIpv4},${ingressMgmtIpv4}"
         ipFamilies:
           - IPv4
           - IPv6


### PR DESCRIPTION
This pull request introduces several improvements and changes to the ingress and service configuration for the `netbootxyz` and `unifi` applications in the `bootstrap00` Kubernetes cluster. The key updates include the addition of ingress resources for both applications, service port cleanups, renaming of service resources, and the introduction of encrypted values for ingress management IPs. These changes enhance security, simplify service exposure, and improve maintainability.

**Ingress and Service Configuration Updates:**

* Added new `Ingress` resources for `netbootxyz` and `unifi`, enabling secure and managed HTTP(S) access via NGINX ingress controller, with appropriate TLS configuration and cluster-issuer annotations. (`kubernetes/apps/bootstrap00/netbootxyz/ingress.yaml`, `kubernetes/apps/bootstrap00/unifi/ingress.yaml`) [[1]](diffhunk://#diff-92276369074e6fab4f11e555c9e0e4a7a204c31dfda7576e7e9f9e76f53f3c3fR1-R25) [[2]](diffhunk://#diff-0e760fd84e0cb63aa039243adc0ab7c5ed0a516c1de1f053be40654f459e1ac4R1-R26)
* Added Cilium IPAM annotations to the ingress-nginx service to specify management IPs for load balancer assignment. (`kubernetes/infrastructure/bootstrap00/ingress-nginx.yaml`)

**Service Port and Resource Cleanups:**

* Removed unused or redundant service ports (`admin`, `admin-http`, and duplicate `admin-https`) from `netbootxyz` and `unifi` service definitions to reduce attack surface and simplify configuration. (`kubernetes/apps/bootstrap00/netbootxyz/services.yaml`, `kubernetes/apps/bootstrap00/unifi/services.yaml`, `kubernetes/apps/bootstrap00/unifi/unifi-network-application.yaml`) [[1]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351L46-L48) [[2]](diffhunk://#diff-b7c266d042c1217351f5e61a21f7abec87d81032faa4e1feee695eb4e56ec88dL18-L20) [[3]](diffhunk://#diff-b7c266d042c1217351f5e61a21f7abec87d81032faa4e1feee695eb4e56ec88dL57-L60) [[4]](diffhunk://#diff-88a88cbe59096c840aeb495a0b67fa2ba7ad9ea2ce56078c8d93a65db3d72694L60-L62)
* Renamed service resources for consistency (e.g., `netbootxyz-tftp-service` to `netbootxyz-service`, `netbootxyz-tftp-k8s00` to `netbootxyz-k8s00`). (`kubernetes/apps/bootstrap00/netbootxyz/services.yaml`) [[1]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351L57-R54) [[2]](diffhunk://#diff-1bbab03f153fc1514915cea96505a3fd584061a7895a748829441ad7a411d351L83-R80)

**Security and Encrypted Values:**

* Added encrypted values for `ingressMgmtIpv4` and `ingressMgmtIpv6` to the cluster's global values, supporting secure management of ingress IP addresses. (`kubernetes/clusters/bootstrap00/global.values.sops.yaml`) [[1]](diffhunk://#diff-28a8f6cdd841b219e537df086be2dee093c292f88cac4b68ccf0cb309592b6bfR27-R28) [[2]](diffhunk://#diff-28a8f6cdd841b219e537df086be2dee093c292f88cac4b68ccf0cb309592b6bfL42-R45)