### PR TITLE
feat: bootstrap00: cert-manager: patch to reduce number of replicas

### DIFF
--- a/kubernetes/clusters/bootstrap00/infrastructure.yaml
+++ b/kubernetes/clusters/bootstrap00/infrastructure.yaml
@@ -43,6 +43,23 @@ spec:
       target:
         kind: DaemonSet
         name: generic-device-plugin
+    - patch: |-
+        apiVersion: helm.toolkit.fluxcd.io/v2
+        kind: HelmRelease
+        metadata:
+          name: cert-manager
+          namespace: cert-manager
+        spec:
+          values:
+            replicaCount: 1
+            webhook:
+              replicaCount: 1
+            cainjector:
+              replicaCount: 1
+      target:
+        kind: HelmRelease
+        name: cert-manager
+        namespace: cert-manager
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
This pull request introduces a configuration update for the `cert-manager` HelmRelease in the Kubernetes cluster bootstrap process. The main change is the addition of a patch to set the replica count for `cert-manager` and its components to 1, ensuring minimal resource usage and high availability for critical services.

Configuration update for cert-manager:

* Added a patch to the `cert-manager` HelmRelease in `infrastructure.yaml` to explicitly set `replicaCount` for `cert-manager`, `webhook`, and `cainjector` to 1.