### PR TITLE
feat: k8s00: apps: Add pihole resources

### DIFF
--- a/kubernetes/apps/k8s00/pihole/helm-repo.yaml
+++ b/kubernetes/apps/k8s00/pihole/helm-repo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: mojo2600
+  namespace: pihole
+spec:
+  interval: 1440m
+  url: https://mojo2600.github.io/pihole-kubernetes/

--- a/kubernetes/apps/k8s00/pihole/namespace.yaml
+++ b/kubernetes/apps/k8s00/pihole/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pihole

--- a/kubernetes/apps/k8s00/pihole/pihole-casa.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-casa.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: pihole-service
+  name: pihole-casa
   namespace: pihole
 spec:
   interval: 5m

--- a/kubernetes/apps/k8s00/pihole/pihole-casa.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-casa.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pihole-service
+  namespace: pihole
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: pihole
+      version: ">=2.36.0 <2.37"
+      sourceRef:
+        kind: HelmRepository
+        name: mojo2600
+        namespace: pihole
+      interval: 1m
+  values:
+    DNS1: "${piholeIpv4ServiceBootstrap00}"
+    DNS2: "${piholeIpv4ServiceK8s00}"
+    admin:
+      enabled: true
+      existingSecret: pihole
+      passwordKey: password
+    doh:
+      enabled: false
+    dualStack:
+      enabled: true
+    extraEnvVars:
+      FTLCONF_dns_listeningMode: 'all'
+    ftl:
+      dns_rateLimit_count: "100000"
+      dns_rateLimit_interval: "15"
+      ntp_ipv4_active: false
+      ntp_ipv6_active: false
+      webserver_interface_boxed: false
+      webserver_interface_theme: default-dark
+    ingress:
+      enabled: true
+      annotations:
+        cert-manager.io/cluster-issuer: homelab-internal
+      ingressClassName: nginx
+      hosts:
+        - piholecasa.k8s00.${mgmtDomainOld}
+      path: /
+      pathType: ImplementationSpecific
+      tls:
+        - hosts:
+            - piholecasa.k8s00.${mgmtDomainOld}
+          secretName: piholecasa.k8s00.${mgmtDomainOld}-tls
+    persistentVolumeClaim:
+      enabled: true
+      size: 500Mi
+    serviceDhcp:
+      enabled: false
+    serviceDns:
+      type: ClusterIP
+    serviceWeb:
+      type: ClusterIP
+    strategyType: Recreate

--- a/kubernetes/apps/k8s00/pihole/pihole-k8s00.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-k8s00.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: pihole-service
+  name: pihole-k8s00
   namespace: pihole
 spec:
   interval: 5m

--- a/kubernetes/apps/k8s00/pihole/pihole-k8s00.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-k8s00.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pihole-service
+  namespace: pihole
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: pihole
+      version: ">=2.36.0 <2.37"
+      sourceRef:
+        kind: HelmRepository
+        name: mojo2600
+        namespace: pihole
+      interval: 1m
+  values:
+    DNS1: "${piholeIpv4ServiceBootstrap00}"
+    DNS2: "${piholeIpv4ServiceK8s00}"
+    admin:
+      enabled: true
+      existingSecret: pihole
+      passwordKey: password
+    doh:
+      enabled: false
+    dualStack:
+      enabled: true
+    extraEnvVars:
+      FTLCONF_dns_listeningMode: 'all'
+    ftl:
+      dns_rateLimit_count: "100000"
+      dns_rateLimit_interval: "15"
+      ntp_ipv4_active: false
+      ntp_ipv6_active: false
+      webserver_interface_boxed: false
+      webserver_interface_theme: default-dark
+    ingress:
+      enabled: true
+      annotations:
+        cert-manager.io/cluster-issuer: homelab-internal
+      ingressClassName: nginx
+      hosts:
+        - piholek8s00.k8s00.${mgmtDomainOld}
+      path: /
+      pathType: ImplementationSpecific
+      tls:
+        - hosts:
+            - piholek8s00.k8s00.${mgmtDomainOld}
+          secretName: piholek8s00.k8s00.${mgmtDomainOld}-tls
+    persistentVolumeClaim:
+      enabled: true
+      size: 500Mi
+    serviceDhcp:
+      enabled: false
+    serviceDns:
+      type: ClusterIP
+    serviceWeb:
+      type: ClusterIP
+    strategyType: Recreate

--- a/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pihole-mgmt
+  namespace: pihole
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: pihole
+      version: ">=2.36.0 <2.37"
+      sourceRef:
+        kind: HelmRepository
+        name: mojo2600
+        namespace: pihole
+      interval: 1m
+  values:
+    DNS1: "${piholeIpv4K8s00Bootstrap00}"
+    DNS2: "${piholeIpv4K8s00K8s00}"
+    admin:
+      enabled: true
+      existingSecret: pihole
+      passwordKey: password
+    dnsmasq:
+      customCnameEntries:
+        - cname=router.${mgmtDomainOld},router
+        - cname=router.${mgmtDomain},router
+        - cname=nas00.${mgmtDomainOld},nas00
+        - cname=nas00.${mgmtDomain},nas00
+      customDnsEntries:
+        - address=/router/${routerIpMgmt}
+        - address=/nas00/${nasIpmgmt}
+      enableCustomDnsMasq: true
+    doh:
+      enabled: false
+    dualStack:
+      enabled: true
+    extraEnvVars:
+      FTLCONF_dns_listeningMode: 'all'
+    ftl:
+      dns_rateLimit_count: "100000"
+      dns_rateLimit_interval: "15"
+      ntp_ipv4_active: false
+      ntp_ipv6_active: false
+      webserver_interface_boxed: false
+      webserver_interface_theme: default-dark
+      misc_dnsmasq_lines: |-
+        server=/${mgmtDomainOld}/${routerIpMgmt}
+        server=/${mgmtDomain}/${routerIpMgmt}
+    ingress:
+      enabled: true
+      annotations:
+        cert-manager.io/cluster-issuer: homelab-internal
+      ingressClassName: nginx
+      hosts:
+        - piholemgmt.k8s00.${mgmtDomainOld}
+      path: /
+      pathType: ImplementationSpecific
+      tls:
+        - hosts:
+            - piholemgmt.k8s00.${mgmtDomainOld}
+          secretName: piholemgmt.k8s00.${mgmtDomainOld}-tls
+    persistentVolumeClaim:
+      enabled: true
+      size: 500Mi
+    serviceDhcp:
+      enabled: false
+    serviceDns:
+      type: ClusterIP
+    serviceWeb:
+      type: ClusterIP
+    strategyType: Recreate

--- a/kubernetes/apps/k8s00/pihole/pihole-service.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-service.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pihole-service
+  namespace: pihole
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: pihole
+      version: ">=2.36.0 <2.37"
+      sourceRef:
+        kind: HelmRepository
+        name: mojo2600
+        namespace: pihole
+      interval: 1m
+  values:
+    DNS1: "${routerIpService}"
+    DNS2: "${routerIpService}#53053"
+    admin:
+      enabled: true
+      existingSecret: pihole
+      passwordKey: password
+    doh:
+      enabled: false
+    dualStack:
+      enabled: true
+    extraEnvVars:
+      FTLCONF_dns_listeningMode: 'all'
+    ftl:
+      dns_rateLimit_count: "100000"
+      dns_rateLimit_interval: "15"
+      ntp_ipv4_active: false
+      ntp_ipv6_active: false
+      webserver_interface_boxed: false
+      webserver_interface_theme: default-dark
+    ingress:
+      enabled: true
+      annotations:
+        cert-manager.io/cluster-issuer: homelab-internal
+      ingressClassName: nginx
+      hosts:
+        - piholeservice.k8s00.${mgmtDomainOld}
+      path: /
+      pathType: ImplementationSpecific
+      tls:
+        - hosts:
+            - piholeservice.k8s00.${mgmtDomainOld}
+          secretName: piholeservice.k8s00.${mgmtDomainOld}-tls
+    persistentVolumeClaim:
+      enabled: true
+      size: 500Mi
+    serviceDhcp:
+      enabled: false
+    serviceDns:
+      type: ClusterIP
+    serviceWeb:
+      type: ClusterIP
+    strategyType: Recreate

--- a/kubernetes/apps/k8s00/pihole/pihole.secrets.sops.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole.secrets.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pihole
+  namespace: pihole
+stringData:
+  password: ENC[AES256_GCM,data:roMe2VL0cAKhjajkqjyZ,iv:Jqzc7823ZwyzIyc9vDq9vFcMw9DDdIs95Hdf1laSiwU=,tag:kfxOKYxqLWRHz7p/3LhkEw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1ZnRvbEFMR0d5bnk4ZGRs
+        NXBzNjYyNTlza3J6S1p1K0tZelRpZVd5L21rCkFKMFAyOTludG9IQVVnSEVzUlNT
+        NWloeEs1K0g0bTlCbmdMMzJzdlRLUWsKLS0tIEE3RVJ4UEJHN0ZWNEZEajVrYXVn
+        cEtCMGMxZkVWRlVNTlFURS9kSk41a2sK9F2y3WToLl33ooXI1W5oCMn9rVl1UqcA
+        BnyHeA8ZNPaWlMKB5gNU4djk9Vb46zj2sBEE+dFLcawMajK2v23JZg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-22T12:58:29Z"
+  mac: ENC[AES256_GCM,data:u9qfcBAYsIYQtyDfDR5dJOckIDE5gwlblgKyoz0951T9xx1RVXiOsNyJnJCvMjzmxbRwO73gxZbagHTZpQngXt0ZUwB+PZFvppUwXVP/WArqW92Zm39Ybsva4/vA5wgIpDn9VIAPCDdErLY4NsNdEm1YgYX/On7ZQTkzPD0+HBY=,iv:xKvTjq8JPO7jtq+oExdn+HDryPJc82XNyB2TtYdY+NU=,tag:JQR606U5DVnJGbdU7vVhJQ==,type:str]
+  version: 3.13.1

--- a/kubernetes/apps/k8s00/pihole/service.yaml
+++ b/kubernetes/apps/k8s00/pihole/service.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-mgmt
+  namespace: pihole
+  labels:
+    app: pihole-mgmt
+    network: mgmt
+  annotations:
+    lbipam.cilium.io/ips: "${piholeIpv4MgmtK8s00}"
+spec:
+  # ipFamilyPolicy: PreferDualStack
+  # ipFamilies:
+  #   - IPv4
+  #   - IPv6
+  ports:
+    - name: dns
+      port: 53
+      protocol: TCP
+      targetPort: dns
+    - name: dns-udp
+      port: 53
+      protocol: UDP
+      targetPort: dns-udp
+  type: LoadBalancer
+  loadBalancerClass: io.cilium/bgp-control-plane
+  selector:
+    app: pihole
+    release: pihole-mgmt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-service
+  namespace: pihole
+  labels:
+    app: pihole-service
+    network: service
+  annotations:
+    lbipam.cilium.io/ips: "${piholeIpv4ServiceK8s00}"
+spec:
+  # ipFamilyPolicy: PreferDualStack
+  # ipFamilies:
+  #   - IPv4
+  #   - IPv6
+  ports:
+    - name: dns
+      port: 53
+      protocol: TCP
+      targetPort: dns
+    - name: dns-udp
+      port: 53
+      protocol: UDP
+      targetPort: dns-udp
+  type: LoadBalancer
+  loadBalancerClass: io.cilium/bgp-control-plane
+  selector:
+    app: pihole
+    release: pihole-service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-casa
+  namespace: pihole
+  labels:
+    app: pihole-casa
+    network: casa
+  annotations:
+    lbipam.cilium.io/ips: "${piholeIpv4CasaK8s00}"
+spec:
+  # ipFamilyPolicy: PreferDualStack
+  # ipFamilies:
+  #   - IPv4
+  #   - IPv6
+  ports:
+    - name: dns
+      port: 53
+      protocol: TCP
+      targetPort: dns
+    - name: dns-udp
+      port: 53
+      protocol: UDP
+      targetPort: dns-udp
+  type: LoadBalancer
+  loadBalancerClass: io.cilium/bgp-control-plane
+  selector:
+    app: pihole
+    release: pihole-casa
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-k8s00
+  namespace: pihole
+  labels:
+    app: pihole-k8s00
+    network: k8s00
+  annotations:
+    lbipam.cilium.io/ips: "${piholeIpv4K8s00K8s00}"
+spec:
+  # ipFamilyPolicy: PreferDualStack
+  # ipFamilies:
+  #   - IPv4
+  #   - IPv6
+  ports:
+    - name: dns
+      port: 53
+      protocol: TCP
+      targetPort: dns
+    - name: dns-udp
+      port: 53
+      protocol: UDP
+      targetPort: dns-udp
+  type: LoadBalancer
+  loadBalancerClass: io.cilium/bgp-control-plane
+  selector:
+    app: pihole
+    release: pihole-k8s00

--- a/kubernetes/clusters/k8s00/global.variables.sops.yaml
+++ b/kubernetes/clusters/k8s00/global.variables.sops.yaml
@@ -1,28 +1,46 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: global-variables
-    namespace: flux-system
+  name: global-variables
+  namespace: flux-system
 stringData:
-    mainDomain: ENC[AES256_GCM,data:0H8u611DFx8=,iv:qj/UczX3JebqdgMOxTlAP/ErcJTWcY7hyi1xK6b7jZk=,tag:tToZ+cCJ4fPe/p4nF0SmKw==,type:str]
-    serviceDomain: ENC[AES256_GCM,data:6pUEIa8JYshjU+cHROHr7RnbupoMq7s1WLO0,iv:olNt9IoBHJuhmg+n1YLglCaJFt+lIGO6ZukSfY2RuGQ=,tag:elWLZS3lye0YIfPlaAAt6g==,type:str]
-    nasIp: ENC[AES256_GCM,data:VuWOIAMcrEx5+t8Pjg==,iv:+p34XqVQAdoTe1mRJvdmnZDcQNvhmqUzHdbJgE6TyXs=,tag:VqdLWXm2mnnA0F/2LEpKRg==,type:str]
-    nasNfsPath: ENC[AES256_GCM,data:pO+GlccozO8=,iv:fwszXZWuLvISUD4dJlmLTodiNpCyGRNRtnSUsJ5oJqY=,tag:OMXE2jMrNPAWO+5o3NecYQ==,type:str]
-    userId: ENC[AES256_GCM,data:ZmXon14=,iv:3ESrO1TGZfQSoOf0UJpDMpjyKpVqtizbxbQsOquTDNE=,tag:v18gjcAjOE+Ms6SapImXSQ==,type:str]
-    groupId: ENC[AES256_GCM,data:MO0HNIc=,iv:74WMzmcmKbY596xNddBGcGBATVfOfnONq3g/+SXIyNY=,tag:SBGSvHX19vYLL1UsQIV3gA==,type:str]
-    timezone: ENC[AES256_GCM,data:9PpxXQ/5U0uhojKp3xji,iv:7ZZVS7RzvqdVzHqyS2oQDFrpCBgeBP5RMf5ql0I6XUY=,tag:+YvhN374i0r/P5i4GEd5CA==,type:str]
+  routerIpMgmt: ENC[AES256_GCM,data:f8mGDDt690x4gjg=,iv:BdBfVIPGE72v/ZmBE4+LrtWCqPY4vVHmCcGGUbPBt/Q=,tag:XRjsaH/rR5FjZFC/ZQ6EoQ==,type:str]
+  routerIpService: ENC[AES256_GCM,data:tz3ZQoCR1rSpRYXI,iv:gxAarmWibolhhSodd9j7Thrcg3WmKyIvVl2FMHoxIB8=,tag:LYleRKzc595cyQVgetri3w==,type:str]
+  nasIp: ENC[AES256_GCM,data:VuWOIAMcrEx5+t8Pjg==,iv:+p34XqVQAdoTe1mRJvdmnZDcQNvhmqUzHdbJgE6TyXs=,tag:VqdLWXm2mnnA0F/2LEpKRg==,type:str]
+  nasIpmgmt: ENC[AES256_GCM,data:0gGpp1iNx0bs4ZyE,iv:4b/Rgl6OkcT/Gg/r5vYQnqotFc4aCVvU+cpqg5D6uL4=,tag:igIPSAmxZY29QP+XPIHlGw==,type:str]
+  nasNfsPath: ENC[AES256_GCM,data:pO+GlccozO8=,iv:fwszXZWuLvISUD4dJlmLTodiNpCyGRNRtnSUsJ5oJqY=,tag:OMXE2jMrNPAWO+5o3NecYQ==,type:str]
+  userId: ENC[AES256_GCM,data:ZmXon14=,iv:3ESrO1TGZfQSoOf0UJpDMpjyKpVqtizbxbQsOquTDNE=,tag:v18gjcAjOE+Ms6SapImXSQ==,type:str]
+  groupId: ENC[AES256_GCM,data:MO0HNIc=,iv:74WMzmcmKbY596xNddBGcGBATVfOfnONq3g/+SXIyNY=,tag:SBGSvHX19vYLL1UsQIV3gA==,type:str]
+  timezone: ENC[AES256_GCM,data:9PpxXQ/5U0uhojKp3xji,iv:7ZZVS7RzvqdVzHqyS2oQDFrpCBgeBP5RMf5ql0I6XUY=,tag:+YvhN374i0r/P5i4GEd5CA==,type:str]
+  mainDomain: ENC[AES256_GCM,data:5M5rEKMzCA==,iv:z7U3EnhoIJwHhOArea4HBG2etxXZoZsOY4bwIIAGQGE=,tag:dLQCu9Cc/bmBlGnA7Xzq5A==,type:str]
+  homeDomainOld: ENC[AES256_GCM,data:DpQCTAYOKicV4TMc1w==,iv:i2iP78fVeKPjWhEBksDv7wBvfU64w0WBpf/Zfb2Q40w=,tag:qqH+ZlZU0bOtnCqbFXd7Hg==,type:str]
+  homeDomain: ENC[AES256_GCM,data:YMJ7/MYuCURqbbS0,iv:vXaDONAPZ4FHcJhcGymyfIBmBHI72vGApoNyz16OtrU=,tag:F5ojG43AZudvSGiPfTr3bw==,type:str]
+  mgmtDomainOld: ENC[AES256_GCM,data:5PrKim/Y7EH9ZXW7cUUyx8be,iv:HdeaCFgE7TZ90FCopg6rpuFZw6BENSCbfWktMOXO8zk=,tag:5GRZxaPopEROz0ejzz7DUQ==,type:str]
+  mgmtDomain: ENC[AES256_GCM,data:6GsD/v4fSTmcfnFJQZJPj5U=,iv:0noG6TtzfgyetizWIJbywBEDm24g5N0jTANazyDzb4k=,tag:zgaYcJqSG3LN7tnJ5wqa7A==,type:str]
+  serviceDomain: ENC[AES256_GCM,data:knKyqKDQFGtDFaN1xp5cRBPNnhM=,iv:Ylz0q4ev/ePV+bMWxYM2okCoyvgu+J+HEa//K4+fTcI=,tag:RdH+qwWFoWoswbffxe/LMw==,type:str]
+  serviceDomainOld: ENC[AES256_GCM,data:TxZv7qa3rgpfock13VCdiaOGgqGT,iv:Qk+aOBwVcpN8pPsAsJjCuFsQ2NCqF53WrqTAPgz3ObQ=,tag:hHsUoDDeLmBftiv0vuU0OQ==,type:str]
+  k8s00Domain: ENC[AES256_GCM,data:EKBvtz2YqhJm628EGKPRaDsd,iv:h9HgcwZv0eGSvkvlnOVTxwVZM+64EcewCJeAkJK51XI=,tag:yeaoqlmQ9jEq97OCfKDomw==,type:str]
+  k8s00DomainOld: ENC[AES256_GCM,data:lyi5BW26g0cENmtxBYp1VVJR0Q==,iv:gesiXsL9VXLUUHzDz8PPzYDdn1hcf6jVGHH+iHEbSbY=,tag:qYJ2bGdWlzAGvBYxUsjJuA==,type:str]
+  piholeUrlMgmtBootstrap00: ENC[AES256_GCM,data:qoKSxZ3jR9xrVMcEEawoyYyrG1WdJStNvS0lv/SGhH9iTsu/d+i8djHmgA/uns14DQ==,iv:L1apPtbzs5SmIUqONf+mUYDmoQ3u8OaWkZJJptZNmvE=,tag:REFcTM1XRFMJ/OKoBOlONw==,type:str]
+  piholeUrlMgmtK8s00: ENC[AES256_GCM,data:dwf+sFV8DXiyEhLcuO2Vj+E01oGZthDkI7oEFyu4Uxssq1wbXyjW0dFIGQ==,iv:XY7N2LvnF4yxr52PqQr9tpiXQAM9Ezz+tW62hSpywPU=,tag:jK2Vt5ZkkEWGFeE4x9H1mQ==,type:str]
+  piholeIpv4MgmtK8s00: ENC[AES256_GCM,data:UC62pO440tQlnBo=,iv:unentwg99dzrqsr+kmd4SsDCTRWkH0QwMwaBksnfWGw=,tag:Ybj1gulfHlZ/BKiQYia0/w==,type:str]
+  piholeIpv4K8s00Bootstrap00: ENC[AES256_GCM,data:qfBxfyr+pU5NJRfu,iv:kW84pgfnp/D7s7bXcz43ALR/NzH61NOU5poYDlRiEVA=,tag:Z2vxhGtK5qlQVyX3EWig8Q==,type:str]
+  piholeIpv4K8s00K8s00: ENC[AES256_GCM,data:gX9enfLgvbapilVq,iv:kUvBms8uh40LR4DV/Hu/+ZSy8L1O07SdqPOclTas4r8=,tag:Blypb8bxBgyiSji5ryDhkA==,type:str]
+  piholeIpv4ServiceBootstrap00: ENC[AES256_GCM,data:SkA3pxOtaAyuDWo=,iv:ziipQUzKxAko3JDxeyOYnSmEvE2b10mujIJ1a0BwGU4=,tag:tRLjyaVduXsPbrg2Ek5Vxg==,type:str]
+  piholeIpv4ServiceK8s00: ENC[AES256_GCM,data:tgxlKaseplFZullM,iv:ZzMdp1MqvUAui+xvYAQKaQMIQwBlKQzk60hNdN0UHU4=,tag:fME1OZ/+sxVbwEQjWkhoUw==,type:str]
+  piholeIpv4CasaK8s00: ENC[AES256_GCM,data:NQ5MW7UOgPlf/74D,iv:Lu2ElPJQouGSlmjVgJriFV6lefoUPL9zQrM5C12pMew=,tag:f4ou8w2S03Hys+IcbD8OhA==,type:str]
 sops:
-    age:
-        - recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPQ0RKS3NldlgzdUJBdkVq
-            S01HWWNTZVRNbVFDRElzelg5dCtiU0MvTWpRClVvdlVCV0gxWXp1eHdDaGpoeEpi
-            cC93TysrUkdoV052aEJaR2s0MGthOFkKLS0tIDU5V3VPS0RCdVR3SFdzY2pjVVFx
-            WldtNFVua1oxSGVYVUZhdTFKd09YeDQKPRdyxqTs2nAtziEEaxh4ggAVia5UKUeQ
-            wRwnpZN5B7Zs9dj28BzILiiu5NiKonj1QoPe3Sl/38mltB9Tdw2Kjw==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-01-30T23:43:00Z"
-    mac: ENC[AES256_GCM,data:NFbyoSCmJDzhV1beYa0XQfnptEFY3dg5Rf2nWW5pkuQrKPfpRCNSNC0o1qnlPng0jREBr0MzIg90m2ZxvODvc9ilTqsLt/bEnlFa9JtS6MpiePF4HJ0CDE5cKow/eAmKcBxQyeUUQX3k1qccsqW7AstksPl2mp19fJR2J04yFOU=,iv:V726f+IBgnfny6JEP3yTnw38+pBoShpvOGUSlS97goY=,tag:QDK3xZyVWb6KB2vRUH4srg==,type:str]
-    encrypted_regex: ^(data|stringData)$
-    version: 3.11.0
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPQ0RKS3NldlgzdUJBdkVq
+        S01HWWNTZVRNbVFDRElzelg5dCtiU0MvTWpRClVvdlVCV0gxWXp1eHdDaGpoeEpi
+        cC93TysrUkdoV052aEJaR2s0MGthOFkKLS0tIDU5V3VPS0RCdVR3SFdzY2pjVVFx
+        WldtNFVua1oxSGVYVUZhdTFKd09YeDQKPRdyxqTs2nAtziEEaxh4ggAVia5UKUeQ
+        wRwnpZN5B7Zs9dj28BzILiiu5NiKonj1QoPe3Sl/38mltB9Tdw2Kjw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-22T12:56:52Z"
+  mac: ENC[AES256_GCM,data:leTAm6hq+Si92rAoCVOD92LivdCXVbvkYDlFEfmum2dWDiV+SSphrBj4LW1TmLgW1Vrct0xI1fw6o3UgghxZFokDizga0bikzaSDDXv6YimnweK2xc0VxxjvsctFc/w1YS7MnN7hVmhxv9HUMEFzszR6QJr+B/e05jLsV7lJ75Q=,iv:4cYZf+QSiP+Zg/EF9u4aEW2DhGHBWoozdpmFhdQDcl8=,tag:QFUChb9KLTL6AMQJOi2UiA==,type:str]
+  version: 3.13.1


### PR DESCRIPTION
This pull request introduces a new deployment of Pi-hole in the `k8s00` Kubernetes cluster using FluxCD and Helm, with multiple environments and services. It adds all necessary Kubernetes manifests, secrets, and supporting variables to enable a robust, multi-environment Pi-hole setup with secure configuration and integration with Cilium for load balancing.

**Key changes:**

**Pi-hole Deployment and Configuration:**
- Added HelmRelease manifests for various Pi-hole environments (`pihole-service`, `pihole-mgmt`, `pihole-casa`, `pihole-k8s00`), each with tailored DNS settings, admin secret integration, ingress configuration, persistent storage, and service exposure. Some environments include custom DNSMasq entries for internal DNS overrides. [[1]](diffhunk://#diff-e19db1c84bcd009d05ec1b40c4774a9b32df3c010914b8b62d2e038049fabc4cR1-R60) [[2]](diffhunk://#diff-7e04604a89db2c49d4a52cb83c124ac4eacd1caf5943714066a1ce48ae6c00b9R1-R60) [[3]](diffhunk://#diff-195c8950f420a5dd1ff5f320f5590ae12537ee26c4bce5153a05969077ddca61R1-R73) [[4]](diffhunk://#diff-c22870880761b0997972dfe65d0c6eb202a778e2745cc73a9bdb33e9feecf7b9R1-R60)
- Created a dedicated `pihole` namespace and registered the external Mojo2600 Helm repository for Pi-hole chart management. [[1]](diffhunk://#diff-c41b978d6862918db015bf652195ab29f9f2d8524e7b75c8f5ef6352868b7d57R1-R5) [[2]](diffhunk://#diff-1ab8bd772cb58e59931eaa0dd7ea75f7d8f14569e1e7aa35b5c8c8fef49c8774R1-R9)

**Service Exposure and Networking:**
- Defined four separate `Service` resources (`pihole-mgmt`, `pihole-service`, `pihole-casa`, `pihole-k8s00`) as Cilium BGP load balancers, each with environment-specific IPs and labels to support network segmentation and high availability.

**Secrets and Secure Configuration:**
- Introduced a SOPS-encrypted Kubernetes Secret for the Pi-hole admin password, ensuring sensitive data is managed securely.
- Updated the global variables secret to include all necessary domain names, IP addresses, and environment-specific variables required for dynamic configuration of the Pi-hole deployments.

**Helm Repository Integration:**
- Added a `HelmRepository` resource to reference the Mojo2600 Pi-hole Helm chart, enabling automated chart retrieval and updates via FluxCD.

These changes collectively automate and secure the deployment of Pi-hole across multiple environments in the cluster, with strong separation, ingress, and DNS customization.