### PR TITLE
feat: k8s00: bgp: add ip pools

### DIFF
--- a/kubernetes/clusters/k8s00/cilium.values.sops.yaml
+++ b/kubernetes/clusters/k8s00/cilium.values.sops.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cilium-values
+  namespace: flux-system
+stringData:
+  ipv4_k8s00_router: ENC[AES256_GCM,data:EJ357XkTIfQg/t2P,iv:Y0GvsO04jd/AdIX9KcC1DvqopdK/TtG7FMDSJeTNsFw=,tag:sMvb0PPjYUQtfws11U73rA==,type:str]
+  ipv4_mgmt_bgp_cidr: ENC[AES256_GCM,data:MSQPlXl7IR3LvmKBEvY=,iv:sVerFdcmc9iiMH3QiXulo4+2CozVpVRkq00q6SQlupg=,tag:EhYx+nS3hnkpjQzPywgr/w==,type:str]
+  ipv4_service_bgp_cidr: ENC[AES256_GCM,data:yRfsgwJPDSlIQvme/L6Z,iv:1IQDzTdwMYzfM2ANHxt9aj12oia2zLOsITWJnyyq43U=,tag:Z/ulnRDD/LGL0JbffCgAMQ==,type:str]
+  ipv4_k8s00_bgp_cidr: ENC[AES256_GCM,data:pGqqAA+CKy5QxC4pmvu5,iv:GbJCRfOBbw8Setp7BBKeGq7Onk5cbd0oFLh4+BmBPa0=,tag:D7g6/cSDMLB442GEFy9ymw==,type:str]
+  ipv4_service_service_bgp_cidr: ENC[AES256_GCM,data:3ZTJYPSCLb9F6usX3vrY,iv:/ReXFlUNvepYAKTy0fYKnobnQcFga3spbCTd4rIMGko=,tag:4sqQ0/UTUpOm4dKLUzkWFA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsNzRmdDVNTDg5OTNiVnhL
+        T2pma0F1bXZOWFk1cS84dVVrUmg2Q3k4M0FZCmZSV0lFeFpOUFZEaHRXYkZHb1ZJ
+        TTN6dHJNYi9BTXpuNDZ4OWxlMWY2YXMKLS0tIG5xUUpyNGpDUjkwN2VUN1dYZ0ha
+        Nkpwc1I3UnVIdWxtQ3plUTZzQU9qZU0KyXhvx3QvjJKSaKTOaIBqqovhMsNGAk25
+        S5u8K4kB5tosISqh9Tm2PCwRCQvDFfCiaQ3Pktl0keploPSdwgNkvA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-22T13:52:55Z"
+  mac: ENC[AES256_GCM,data:gl6OiM6RMkxJ7+QkSQ+iPw+X2O8dGeAvFFcn7VDgaa6mth/neJcuErVL2Dc4tqZY9romayxaYRFqg2Jb5ICcGvKClZvRXPMeceQH5WoSyx6ExGcwPfYZUXM3K0b6+K1uswC1gX1Cj3oyuRlcqSwaqV2lTTfmwnLoFBgKweFKR8I=,iv:ReF4UAO+7Y6x5IZ4/IPfuwquzkJA/91m8V8QMj2loeM=,tag:T5bNu0c1lQL0re4p29Bebw==,type:str]
+  version: 3.13.1

--- a/kubernetes/clusters/k8s00/infrastructure.yaml
+++ b/kubernetes/clusters/k8s00/infrastructure.yaml
@@ -62,6 +62,8 @@ spec:
   postBuild:
     substituteFrom:
       - kind: Secret
+        name: cilium-values
+      - kind: Secret
         name: external-dns-values
       - kind: Secret
         name: cert-manager-issuers-secret-values

--- a/kubernetes/infrastructure/k8s00/cilium-bgp/bgp-cluster-config.yaml
+++ b/kubernetes/infrastructure/k8s00/cilium-bgp/bgp-cluster-config.yaml
@@ -13,6 +13,6 @@ spec:
       peers:
         - name: "opnsense-service-k8s00"
           peerASN: 64512
-          peerAddress: "192.168.40.1"
+          peerAddress: "${ipv4_k8s00_router}"
           peerConfigRef:
             name: "cilium-peer"

--- a/kubernetes/infrastructure/k8s00/cilium-bgp/load-balancer-ip-pool.yaml
+++ b/kubernetes/infrastructure/k8s00/cilium-bgp/load-balancer-ip-pool.yaml
@@ -6,5 +6,51 @@ metadata:
 spec:
   allowFirstLastIPs: "No"
   blocks:
-    - cidr: 192.168.90.0/24
+    - cidr: ${ipv4_service_service_bgp_cidr}
   disabled: false
+  serviceSelector:
+    matchExpressions:
+      - key: network
+        operator: DoesNotExist
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: service-pool-mgmt
+spec:
+  allowFirstLastIPs: "No"
+  blocks:
+    - cidr: ${ipv4_mgmt_bgp_cidr}
+    # - cidr: ${ipv6_mgmt_bgp_cidr}
+  disabled: false
+  serviceSelector:
+    matchLabels:
+      network: mgmt
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: service-pool-service
+spec:
+  allowFirstLastIPs: "No"
+  blocks:
+    - cidr: ${ipv4_service_bgp_cidr}
+    # - cidr: ${ipv6_service_bgp_cidr}
+  disabled: false
+  serviceSelector:
+    matchLabels:
+      network: service
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: service-pool-k8s00
+spec:
+  allowFirstLastIPs: "No"
+  blocks:
+    - cidr: ${ipv4_k8s00_bgp_cidr}
+    # - cidr: ${ipv6_k8s00_bgp_cidr}
+  disabled: false
+  serviceSelector:
+    matchLabels:
+      network: k8s00


### PR DESCRIPTION
This pull request updates the Cilium BGP and LoadBalancer IP pool configuration for the `k8s00` Kubernetes cluster to improve flexibility and security by moving sensitive and environment-specific values to encrypted secrets, and by introducing more granular IP pool definitions.

The most important changes are:

**Secret Management and Parameterization:**

* Added a new encrypted `Secret` (`cilium-values`) in `cilium.values.sops.yaml` to securely store BGP and router IP/CIDR values, enabling safe parameter substitution in manifests.
* Updated the BGP peer configuration in `bgp-cluster-config.yaml` to reference the router IP via the new secret (`${ipv4_k8s00_router}`) instead of a hardcoded IP address.

**LoadBalancer IP Pool Configuration:**

* Refactored `load-balancer-ip-pool.yaml` to replace hardcoded CIDRs with secret-based variables (e.g., `${ipv4_service_service_bgp_cidr}`), ensuring all sensitive network ranges are managed securely and centrally.
* Introduced multiple `CiliumLoadBalancerIPPool` resources, each with a distinct `serviceSelector` for different network types (`mgmt`, `service`, `k8s00`), allowing for more granular control over IP allocations for services based on their network labels.
* Enhanced service selection logic by adding `matchExpressions` and `matchLabels` to `serviceSelector`, improving how services are matched to IP pools.