### PR TITLE
fix: k8s00: apps: pihole: switch to single stack

### DIFF
--- a/kubernetes/apps/k8s00/pihole/pihole-casa.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-casa.yaml
@@ -25,7 +25,7 @@ spec:
     doh:
       enabled: false
     dualStack:
-      enabled: true
+      enabled: false
     extraEnvVars:
       FTLCONF_dns_listeningMode: 'all'
     ftl:

--- a/kubernetes/apps/k8s00/pihole/pihole-k8s00.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-k8s00.yaml
@@ -25,7 +25,7 @@ spec:
     doh:
       enabled: false
     dualStack:
-      enabled: true
+      enabled: false
     extraEnvVars:
       FTLCONF_dns_listeningMode: 'all'
     ftl:

--- a/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
@@ -35,7 +35,7 @@ spec:
     doh:
       enabled: false
     dualStack:
-      enabled: true
+      enabled: false
     extraEnvVars:
       FTLCONF_dns_listeningMode: 'all'
     ftl:

--- a/kubernetes/apps/k8s00/pihole/pihole-service.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-service.yaml
@@ -25,7 +25,7 @@ spec:
     doh:
       enabled: false
     dualStack:
-      enabled: true
+      enabled: false
     extraEnvVars:
       FTLCONF_dns_listeningMode: 'all'
     ftl:


### PR DESCRIPTION
This pull request updates the configuration for the Pi-hole deployments in the Kubernetes cluster by disabling dual-stack networking. The change is applied consistently across all Pi-hole related YAML files for the `k8s00` environment.

Networking configuration changes:

* Disabled the `dualStack` feature (`dualStack.enabled: false`) in the following Pi-hole deployment files to ensure only single-stack networking is used:
  - `pihole-casa.yaml`
  - `pihole-k8s00.yaml`
  - `pihole-mgmt.yaml`
  - `pihole-service.yaml`