### PR TITLE
feat: k8s00: bgp: add ip pool casa

### DIFF
--- a/kubernetes/clusters/k8s00/cilium.values.sops.yaml
+++ b/kubernetes/clusters/k8s00/cilium.values.sops.yaml
@@ -9,7 +9,7 @@ stringData:
   ipv4_service_bgp_cidr: ENC[AES256_GCM,data:yRfsgwJPDSlIQvme/L6Z,iv:1IQDzTdwMYzfM2ANHxt9aj12oia2zLOsITWJnyyq43U=,tag:Z/ulnRDD/LGL0JbffCgAMQ==,type:str]
   ipv4_k8s00_bgp_cidr: ENC[AES256_GCM,data:pGqqAA+CKy5QxC4pmvu5,iv:GbJCRfOBbw8Setp7BBKeGq7Onk5cbd0oFLh4+BmBPa0=,tag:D7g6/cSDMLB442GEFy9ymw==,type:str]
   ipv4_service_service_bgp_cidr: ENC[AES256_GCM,data:3ZTJYPSCLb9F6usX3vrY,iv:/ReXFlUNvepYAKTy0fYKnobnQcFga3spbCTd4rIMGko=,tag:4sqQ0/UTUpOm4dKLUzkWFA==,type:str]
-  ipv4_casa_bgp_cide: ENC[AES256_GCM,data:/iJFT1iVIQglgz9Z0Dd1,iv:qFkdoPBcBQqyIP1dWea0iI8xm7sPLYF6hZsdPODTbGU=,tag:+dqV4XWLVbOeQ6cTLpuc9g==,type:str]
+  ipv4_casa_bgp_cidr: ENC[AES256_GCM,data:eecWxOXgwVmT0WCJTqjT,iv:ZQ//mHvUs7TtiPW4X97SahFGCWtvmaWzyvd2PXAY4HI=,tag:/nogg6XNpJTSKNrROgFe7A==,type:str]
 sops:
   age:
     - enc: |
@@ -22,6 +22,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-22T20:35:37Z"
-  mac: ENC[AES256_GCM,data:IeFRE9EAs1huZjlmA6eOwDrE1O8EC8PZdvHKcbdgYOK6CO1fn3DaVFtQ/8dnCqRwdV9iZorR8j0ajM+lyN6JMGzPXdMj4Gkz7VlDhCPnlzMwrc5+THvgeO7QkPcXCMl+SSDCB1d38QviEDgdUKNLB3kfeYU6zw3VjHU6L73KF3Y=,iv:S8sNw28Kj/ZD4KQfoChyxrUfzjLcnl0RXgjc7xfQq1c=,tag:VEY3QZ3hf1OQAwFM3HDmtw==,type:str]
+  lastmodified: "2026-06-22T20:45:36Z"
+  mac: ENC[AES256_GCM,data:lt59sMT+3I6XgF2aef4HjEIFdzOVzBP3Cbw/xcDVwAGLKEh/tHcnI+aRDAaytdGCwUovvuPlRGJasE8eIf0vGccwPH89mDWuLE/EgGGCqfNkykBiwcdnu+UK9HYWVip4LcL+OUuGAqW4j4tlDc5+ZvrbRAvrBOnOW4/8SFyLMqM=,iv:MG7tj4eR6o1nwVGcGYON0OX83WdiS23xmXC9OUbSQiA=,tag:gRUTANmXSotpMKhDTbtbgg==,type:str]
   version: 3.13.1

--- a/kubernetes/clusters/k8s00/cilium.values.sops.yaml
+++ b/kubernetes/clusters/k8s00/cilium.values.sops.yaml
@@ -9,6 +9,7 @@ stringData:
   ipv4_service_bgp_cidr: ENC[AES256_GCM,data:yRfsgwJPDSlIQvme/L6Z,iv:1IQDzTdwMYzfM2ANHxt9aj12oia2zLOsITWJnyyq43U=,tag:Z/ulnRDD/LGL0JbffCgAMQ==,type:str]
   ipv4_k8s00_bgp_cidr: ENC[AES256_GCM,data:pGqqAA+CKy5QxC4pmvu5,iv:GbJCRfOBbw8Setp7BBKeGq7Onk5cbd0oFLh4+BmBPa0=,tag:D7g6/cSDMLB442GEFy9ymw==,type:str]
   ipv4_service_service_bgp_cidr: ENC[AES256_GCM,data:3ZTJYPSCLb9F6usX3vrY,iv:/ReXFlUNvepYAKTy0fYKnobnQcFga3spbCTd4rIMGko=,tag:4sqQ0/UTUpOm4dKLUzkWFA==,type:str]
+  ipv4_casa_bgp_cide: ENC[AES256_GCM,data:/iJFT1iVIQglgz9Z0Dd1,iv:qFkdoPBcBQqyIP1dWea0iI8xm7sPLYF6hZsdPODTbGU=,tag:+dqV4XWLVbOeQ6cTLpuc9g==,type:str]
 sops:
   age:
     - enc: |
@@ -21,6 +22,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-22T13:52:55Z"
-  mac: ENC[AES256_GCM,data:gl6OiM6RMkxJ7+QkSQ+iPw+X2O8dGeAvFFcn7VDgaa6mth/neJcuErVL2Dc4tqZY9romayxaYRFqg2Jb5ICcGvKClZvRXPMeceQH5WoSyx6ExGcwPfYZUXM3K0b6+K1uswC1gX1Cj3oyuRlcqSwaqV2lTTfmwnLoFBgKweFKR8I=,iv:ReF4UAO+7Y6x5IZ4/IPfuwquzkJA/91m8V8QMj2loeM=,tag:T5bNu0c1lQL0re4p29Bebw==,type:str]
+  lastmodified: "2026-06-22T20:35:37Z"
+  mac: ENC[AES256_GCM,data:IeFRE9EAs1huZjlmA6eOwDrE1O8EC8PZdvHKcbdgYOK6CO1fn3DaVFtQ/8dnCqRwdV9iZorR8j0ajM+lyN6JMGzPXdMj4Gkz7VlDhCPnlzMwrc5+THvgeO7QkPcXCMl+SSDCB1d38QviEDgdUKNLB3kfeYU6zw3VjHU6L73KF3Y=,iv:S8sNw28Kj/ZD4KQfoChyxrUfzjLcnl0RXgjc7xfQq1c=,tag:VEY3QZ3hf1OQAwFM3HDmtw==,type:str]
   version: 3.13.1

--- a/kubernetes/infrastructure/k8s00/cilium-bgp/load-balancer-ip-pool.yaml
+++ b/kubernetes/infrastructure/k8s00/cilium-bgp/load-balancer-ip-pool.yaml
@@ -54,3 +54,17 @@ spec:
   serviceSelector:
     matchLabels:
       network: k8s00
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: service-pool-casa
+spec:
+  allowFirstLastIPs: "No"
+  blocks:
+    - cidr: ${ipv4_casa_bgp_cidr}
+    # - cidr: ${ipv6_casa_bgp_cidr}
+  disabled: false
+  serviceSelector:
+    matchLabels:
+      network: k8s00

--- a/kubernetes/infrastructure/k8s00/cilium-bgp/load-balancer-ip-pool.yaml
+++ b/kubernetes/infrastructure/k8s00/cilium-bgp/load-balancer-ip-pool.yaml
@@ -67,4 +67,4 @@ spec:
   disabled: false
   serviceSelector:
     matchLabels:
-      network: k8s00
+      network: casa


### PR DESCRIPTION
This pull request introduces a new BGP IP pool specifically for the "casa" service in the Kubernetes cluster configuration. The main changes involve securely adding the new CIDR value for this pool and updating the load balancer IP pool configuration to reference it.

**Configuration for new "casa" BGP IP pool:**

* Added a new encrypted entry `ipv4_casa_bgp_cidr` to `stringData` in `cilium.values.sops.yaml` for securely storing the CIDR used by the "casa" service pool.
* Updated the SOPS metadata (`lastmodified` and `mac`) in `cilium.values.sops.yaml` to reflect the new encrypted data.

**Load balancer IP pool definition:**

* Added a new `CiliumLoadBalancerIPPool` resource named `service-pool-casa` in `load-balancer-ip-pool.yaml`, which uses the `${ipv4_casa_bgp_cidr}` value for its CIDR block and matches services labeled with `network: k8s00`.