### PR TITLE
fix: k8s00: bgp: wrong peer ip

### DIFF
--- a/kubernetes/clusters/k8s00/cilium.values.sops.yaml
+++ b/kubernetes/clusters/k8s00/cilium.values.sops.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cilium-values
   namespace: flux-system
 stringData:
-  ipv4_k8s00_router: ENC[AES256_GCM,data:EJ357XkTIfQg/t2P,iv:Y0GvsO04jd/AdIX9KcC1DvqopdK/TtG7FMDSJeTNsFw=,tag:sMvb0PPjYUQtfws11U73rA==,type:str]
+  ipv4_k8s00_router: ENC[AES256_GCM,data:y2JLdg7h8I0xeAyP,iv:FRbQwIahawChnv2z9Bp66p7fsK8nKAusP2Z/Qe6aLjs=,tag:GsxFPgDFL6mW6G2Jrngxng==,type:str]
   ipv4_mgmt_bgp_cidr: ENC[AES256_GCM,data:MSQPlXl7IR3LvmKBEvY=,iv:sVerFdcmc9iiMH3QiXulo4+2CozVpVRkq00q6SQlupg=,tag:EhYx+nS3hnkpjQzPywgr/w==,type:str]
   ipv4_service_bgp_cidr: ENC[AES256_GCM,data:yRfsgwJPDSlIQvme/L6Z,iv:1IQDzTdwMYzfM2ANHxt9aj12oia2zLOsITWJnyyq43U=,tag:Z/ulnRDD/LGL0JbffCgAMQ==,type:str]
   ipv4_k8s00_bgp_cidr: ENC[AES256_GCM,data:pGqqAA+CKy5QxC4pmvu5,iv:GbJCRfOBbw8Setp7BBKeGq7Onk5cbd0oFLh4+BmBPa0=,tag:D7g6/cSDMLB442GEFy9ymw==,type:str]
@@ -22,6 +22,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-22T20:45:36Z"
-  mac: ENC[AES256_GCM,data:lt59sMT+3I6XgF2aef4HjEIFdzOVzBP3Cbw/xcDVwAGLKEh/tHcnI+aRDAaytdGCwUovvuPlRGJasE8eIf0vGccwPH89mDWuLE/EgGGCqfNkykBiwcdnu+UK9HYWVip4LcL+OUuGAqW4j4tlDc5+ZvrbRAvrBOnOW4/8SFyLMqM=,iv:MG7tj4eR6o1nwVGcGYON0OX83WdiS23xmXC9OUbSQiA=,tag:gRUTANmXSotpMKhDTbtbgg==,type:str]
+  lastmodified: "2026-06-23T10:14:18Z"
+  mac: ENC[AES256_GCM,data:v/VuW3dtF77zqQAKoeXc2zLJ4g5MPwLYLPnte1FanrZ/Gu4JBDuh/gbZHpsVLZNie1/DCwEX7IyVz8nLim64uiMytam1cpOMsd5y7MuRBhqC2FjvVH3DddQQ9RemFYeBGTiX0nnkR8PYhZ0BPCgedAyJnJqbv/ID8qPmrxAnCYg=,iv:zGmZCQuh4x8roTR5b4RsfNAUUmrNp9HCNrSTmpjUgh4=,tag:pRP6AMLGWm7TouPKYkzJsg==,type:str]
   version: 3.13.1

--- a/kubernetes/clusters/k8s00/global.variables.sops.yaml
+++ b/kubernetes/clusters/k8s00/global.variables.sops.yaml
@@ -27,7 +27,7 @@ stringData:
   piholeIpv4MgmtK8s00: ENC[AES256_GCM,data:UC62pO440tQlnBo=,iv:unentwg99dzrqsr+kmd4SsDCTRWkH0QwMwaBksnfWGw=,tag:Ybj1gulfHlZ/BKiQYia0/w==,type:str]
   piholeIpv4K8s00Bootstrap00: ENC[AES256_GCM,data:qfBxfyr+pU5NJRfu,iv:kW84pgfnp/D7s7bXcz43ALR/NzH61NOU5poYDlRiEVA=,tag:Z2vxhGtK5qlQVyX3EWig8Q==,type:str]
   piholeIpv4K8s00K8s00: ENC[AES256_GCM,data:gX9enfLgvbapilVq,iv:kUvBms8uh40LR4DV/Hu/+ZSy8L1O07SdqPOclTas4r8=,tag:Blypb8bxBgyiSji5ryDhkA==,type:str]
-  piholeIpv4ServiceBootstrap00: ENC[AES256_GCM,data:SkA3pxOtaAyuDWo=,iv:ziipQUzKxAko3JDxeyOYnSmEvE2b10mujIJ1a0BwGU4=,tag:tRLjyaVduXsPbrg2Ek5Vxg==,type:str]
+  piholeIpv4ServiceBootstrap00: ENC[AES256_GCM,data:C00MbSZMo8IaOHI5,iv:KRKs/x0lOB345VZLUPoNCq2z38uLo5IEzGUi4ngpmIw=,tag:JDfxG3npv3Li8ExWpVmDJg==,type:str]
   piholeIpv4ServiceK8s00: ENC[AES256_GCM,data:tgxlKaseplFZullM,iv:ZzMdp1MqvUAui+xvYAQKaQMIQwBlKQzk60hNdN0UHU4=,tag:fME1OZ/+sxVbwEQjWkhoUw==,type:str]
   piholeIpv4CasaK8s00: ENC[AES256_GCM,data:NQ5MW7UOgPlf/74D,iv:Lu2ElPJQouGSlmjVgJriFV6lefoUPL9zQrM5C12pMew=,tag:f4ou8w2S03Hys+IcbD8OhA==,type:str]
 sops:
@@ -42,6 +42,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-22T21:35:36Z"
-  mac: ENC[AES256_GCM,data:SgdK0NDqolA2zXjG1uakNEKzs5FESlvlFieJDe7h7jyAOJIXMuud9nxnvrSnhiDiAgFiKwJPPAj0XkIgSkQR48xzUNHBLJJXlGfhjYEsv9CuSY4Gr01TDtpuod+w3n/FzoOHqTCPkrMkS4iiL2nJLkj+TpFpyhguQn8dO8huK1o=,iv:pU7j8egYJ+RI//J5VYxlPV/aH1caNkfih5vgwyixVms=,tag:cQp/aGMTy8JKIDS3Pdpaiw==,type:str]
+  lastmodified: "2026-06-23T10:38:30Z"
+  mac: ENC[AES256_GCM,data:JQ+kX/HUqQYYDYIf7fhXVA308jrgz6E3BdrJH+lOj+rcAonwGWK8LwgndbN7dOiymk1qZj2aC2SzOR5Vhz1DERHKdxjk30CgjPJcwTHse5CRkkBQtflGY6okLG+kPX7iBCYa1umv04w5l88sPu5rapj0ntovPvrV3y5g3hkFVK8=,iv:2saVWYpplFnjwOfqtQNYxe7b7qGFnOAqMYR3ESzoVWI=,tag:NjlNikIN4X/ioFwj3+rRhA==,type:str]
   version: 3.13.1


### PR DESCRIPTION
This pull request updates encrypted values in the Kubernetes secrets for the `k8s00` cluster. The changes are limited to the rotation of encrypted secrets and their associated metadata, with no changes to application logic or configuration structure.

Key changes:

**Secret value rotation:**

* [`kubernetes/clusters/k8s00/cilium.values.sops.yaml`](diffhunk://#diff-6840c255c8bac9763febd8898d0e8505ceb1bd58497258809af0467fce53a2bfL7-R7): Rotated the encrypted value for `ipv4_k8s00_router` in the `stringData` section.
* [`kubernetes/clusters/k8s00/global.variables.sops.yaml`](diffhunk://#diff-a1864963c08f069e3d37bdaac3d9525655e0bf861d58537f3c8b76d984ed2f87L30-R30): Rotated the encrypted value for `piholeIpv4ServiceBootstrap00` in the `stringData` section.

**Metadata updates:**

* [`kubernetes/clusters/k8s00/cilium.values.sops.yaml`](diffhunk://#diff-6840c255c8bac9763febd8898d0e8505ceb1bd58497258809af0467fce53a2bfL25-R26): Updated the `lastmodified` timestamp and `mac` (message authentication code) in the `sops` section to reflect the new encryption.
* [`kubernetes/clusters/k8s00/global.variables.sops.yaml`](diffhunk://#diff-a1864963c08f069e3d37bdaac3d9525655e0bf861d58537f3c8b76d984ed2f87L45-R46): Updated the `lastmodified` timestamp and `mac` in the `sops` section to reflect the new encryption.