### PR TITLE
fix: k8s00 and bootstrap00: external-dns: duplicate name

### DIFF
--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-bootstrap00.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-bootstrap00.yaml
@@ -18,6 +18,9 @@ spec:
   patches:
     - patch: |
         - op: replace
+          path: /metadata/name
+          value: external-dns-pihole-bootstrap00
+        - op: replace
           path: /spec/template/spec/containers/0/args
           value:
             - --source=service

--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-k8s00.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-k8s00.yaml
@@ -18,6 +18,9 @@ spec:
   patches:
     - patch: |
         - op: replace
+          path: /metadata/name
+          value: external-dns-pihole-k8s00
+        - op: replace
           path: /spec/template/spec/containers/0/args
           value:
             - --source=service

--- a/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-bootstrap00.yaml
+++ b/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-bootstrap00.yaml
@@ -18,6 +18,9 @@ spec:
   patches:
     - patch: |
         - op: replace
+          path: /metadata/name
+          value: external-dns-pihole-bootstrap00
+        - op: replace
           path: /spec/template/spec/containers/0/args
           value:
             - --source=service

--- a/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-k8s00.yaml
+++ b/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-k8s00.yaml
@@ -18,6 +18,9 @@ spec:
   patches:
     - patch: |
         - op: replace
+          path: /metadata/name
+          value: external-dns-pihole-k8s00
+        - op: replace
           path: /spec/template/spec/containers/0/args
           value:
             - --source=service


### PR DESCRIPTION
This pull request updates the Kubernetes patch manifests for the external-dns Pi-hole deployments to explicitly set the `metadata.name` field in each patch. This ensures that the correct resource is targeted during patching and improves clarity and reliability in deployment scripts.

Manifest patch improvements:

* Added a patch operation to explicitly set the `metadata.name` for `external-dns-pihole-bootstrap00` in both the `bootstrap00` and `k8s00` environments (`external-dns-pihole-bootstrap00.yaml`).
* Added a patch operation to explicitly set the `metadata.name` for `external-dns-pihole-k8s00` in both the `bootstrap00` and `k8s00` environments (`external-dns-pihole-k8s00.yaml`).