### PR TITLE
feat: k8s00 and bootstrap00: external-dns: switch to helm

### DIFF
--- a/kubernetes/infrastructure/base/external-dns.yaml
+++ b/kubernetes/infrastructure/base/external-dns.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-dns
+  namespace: cert-manager
+spec:
+  interval: 1440m
+  url: https://kubernetes-sigs.github.io/external-dns/

--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-bootstrap00.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-bootstrap00.yaml
@@ -1,49 +1,99 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
 metadata:
   name: external-dns-pihole-bootstrap00
-  namespace: cert-manager
+  namespace: kube-system
 spec:
-  interval: 1440m
-  retryInterval: 1m
-  timeout: 5m
-  sourceRef:
-    kind: GitRepository
-    name: external-dns
-  path: ./kustomize
-  targetNamespace: cert-manager
-  prune: true
-  wait: true
-  patches:
-    - patch: |
-        - op: replace
-          path: /metadata/name
-          value: external-dns-pihole-bootstrap00
-        - op: replace
-          path: /spec/template/spec/containers/0/args
-          value:
-            - --source=service
-            - --source=ingress
-            # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
-            # You don't need to set this flag, but if you leave it unset, you will receive warning
-            # logs when ExternalDNS attempts to create TXT records.
-            - --registry=noop
-            # IMPORTANT: If you have records that you manage manually in Pi-hole, set
-            # the policy to upsert-only so they do not get deleted.
-            - --policy=upsert-only
-            - --provider=pihole
-            # Switch to pihole V6 API
-            - --pihole-api-version=6
-            # Change this to the actual address of your Pi-hole web server
-            - --pihole-server=${piholeUrlMgmtBootstrap00}
-            # - --pihole-tls-skip-verify
-        - op: add
-          path: /spec/template/spec/containers/0/envFrom
-          value:
-            - secretRef:
-                # Change this if you gave the secret a different name
-                name: pihole-password
-      target:
-        kind: Deployment
+  interval: 5m
+  chart:
+    spec:
+      chart: external-dns
+      version: ">=1.21.1 <1.22.0"
+      sourceRef:
+        kind: HelmRepository
         name: external-dns
+        namespace: cert-manager
+      interval: 1m
+  values:
+    env:
+      - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: EXTERNAL_DNS_PIHOLE_PASSWORD
+            name: pihole-password
+    extraArgs:
+      - --pihole-api-version=6
+      - --pihole-server=${piholeUrlMgmtBootstrap00}
+      - --pihole-tls-skip-verify
+    interval: 1m
+    namespaced: false
+    # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+    # the policy to upsert-only so they do not get deleted.
+    policy: upsert-only
+    provider:
+      name: pihole
+    # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+    # You don't need to set this flag, but if you leave it unset, you will receive warning
+    # logs when ExternalDNS attempts to create TXT records.
+    registry: noop
+    replicaCount: 1
+    service:
+      enabled: true
+      ipFamilies: []
+      ipFamilyPolicy: null
+    serviceMonitor:
+      enabled: false
+    sources:
+      - service
+      - ingress
+      # - gateway-httproute
+---
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: external-dns-pihole-bootstrap00
+#   namespace: cert-manager
+# spec:
+#   interval: 1440m
+#   retryInterval: 1m
+#   timeout: 5m
+#   sourceRef:
+#     kind: GitRepository
+#     name: external-dns
+#   path: ./kustomize
+#   targetNamespace: cert-manager
+#   prune: true
+#   wait: true
+#   patches:
+#     - patch: |
+#         - op: replace
+#           path: /metadata/name
+#           value: external-dns-pihole-bootstrap00
+#         - op: replace
+#           path: /spec/template/spec/containers/0/args
+#           value:
+#             - --source=service
+#             - --source=ingress
+#             # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+#             # You don't need to set this flag, but if you leave it unset, you will receive warning
+#             # logs when ExternalDNS attempts to create TXT records.
+#             - --registry=noop
+#             # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+#             # the policy to upsert-only so they do not get deleted.
+#             - --policy=upsert-only
+#             - --provider=pihole
+#             # Switch to pihole V6 API
+#             - --pihole-api-version=6
+#             # Change this to the actual address of your Pi-hole web server
+#             - --pihole-server=${piholeUrlMgmtBootstrap00}
+#             # - --pihole-tls-skip-verify
+#         - op: add
+#           path: /spec/template/spec/containers/0/envFrom
+#           value:
+#             - secretRef:
+#                 # Change this if you gave the secret a different name
+#                 name: pihole-password
+#       target:
+#         kind: Deployment
+#         name: external-dns

--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-bootstrap00.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-bootstrap00.yaml
@@ -3,7 +3,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: external-dns-pihole-bootstrap00
-  namespace: kube-system
+  namespace: cert-manager
 spec:
   interval: 5m
   chart:

--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-k8s00.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-k8s00.yaml
@@ -1,4 +1,54 @@
 ---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns-pihole-k8s00
+  namespace: kube-system
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: external-dns
+      version: ">=1.21.1 <1.22.0"
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: cert-manager
+      interval: 1m
+  values:
+    env:
+      - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: EXTERNAL_DNS_PIHOLE_PASSWORD
+            name: pihole-password
+    extraArgs:
+      - --pihole-api-version=6
+      - --pihole-server=${piholeUrlMgmtK8s00}
+      - --pihole-tls-skip-verify
+    interval: 1m
+    namespaced: false
+    # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+    # the policy to upsert-only so they do not get deleted.
+    policy: upsert-only
+    provider:
+      name: pihole
+    # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+    # You don't need to set this flag, but if you leave it unset, you will receive warning
+    # logs when ExternalDNS attempts to create TXT records.
+    registry: noop
+    replicaCount: 1
+    service:
+      enabled: true
+      ipFamilies: []
+      ipFamilyPolicy: null
+    serviceMonitor:
+      enabled: false
+    sources:
+      - service
+      - ingress
+      # - gateway-httproute
+---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-k8s00.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-k8s00.yaml
@@ -3,7 +3,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: external-dns-pihole-k8s00
-  namespace: kube-system
+  namespace: cert-manager
 spec:
   interval: 5m
   chart:

--- a/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-bootstrap00.yaml
+++ b/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-bootstrap00.yaml
@@ -1,49 +1,99 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
 metadata:
   name: external-dns-pihole-bootstrap00
-  namespace: cert-manager
+  namespace: kube-system
 spec:
-  interval: 1440m
-  retryInterval: 1m
-  timeout: 5m
-  sourceRef:
-    kind: GitRepository
-    name: external-dns
-  path: ./kustomize
-  targetNamespace: cert-manager
-  prune: true
-  wait: true
-  patches:
-    - patch: |
-        - op: replace
-          path: /metadata/name
-          value: external-dns-pihole-bootstrap00
-        - op: replace
-          path: /spec/template/spec/containers/0/args
-          value:
-            - --source=service
-            - --source=ingress
-            # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
-            # You don't need to set this flag, but if you leave it unset, you will receive warning
-            # logs when ExternalDNS attempts to create TXT records.
-            - --registry=noop
-            # IMPORTANT: If you have records that you manage manually in Pi-hole, set
-            # the policy to upsert-only so they do not get deleted.
-            - --policy=upsert-only
-            - --provider=pihole
-            # Switch to pihole V6 API
-            - --pihole-api-version=6
-            # Change this to the actual address of your Pi-hole web server
-            - --pihole-server=${piholeUrlMgmtBootstrap00}
-            # - --pihole-tls-skip-verify
-        - op: add
-          path: /spec/template/spec/containers/0/envFrom
-          value:
-            - secretRef:
-                # Change this if you gave the secret a different name
-                name: pihole-password
-      target:
-        kind: Deployment
+  interval: 5m
+  chart:
+    spec:
+      chart: external-dns
+      version: ">=1.21.1 <1.22.0"
+      sourceRef:
+        kind: HelmRepository
         name: external-dns
+        namespace: cert-manager
+      interval: 1m
+  values:
+    env:
+      - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: EXTERNAL_DNS_PIHOLE_PASSWORD
+            name: pihole-password
+    extraArgs:
+      - --pihole-api-version=6
+      - --pihole-server=${piholeUrlMgmtBootstrap00}
+      - --pihole-tls-skip-verify
+    interval: 1m
+    namespaced: false
+    # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+    # the policy to upsert-only so they do not get deleted.
+    policy: upsert-only
+    provider:
+      name: pihole
+    # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+    # You don't need to set this flag, but if you leave it unset, you will receive warning
+    # logs when ExternalDNS attempts to create TXT records.
+    registry: noop
+    replicaCount: 1
+    service:
+      enabled: true
+      ipFamilies: []
+      ipFamilyPolicy: null
+    serviceMonitor:
+      enabled: false
+    sources:
+      - service
+      - ingress
+      # - gateway-httproute
+---
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: external-dns-pihole-bootstrap00
+#   namespace: cert-manager
+# spec:
+#   interval: 1440m
+#   retryInterval: 1m
+#   timeout: 5m
+#   sourceRef:
+#     kind: GitRepository
+#     name: external-dns
+#   path: ./kustomize
+#   targetNamespace: cert-manager
+#   prune: true
+#   wait: true
+#   patches:
+#     - patch: |
+#         - op: replace
+#           path: /metadata/name
+#           value: external-dns-pihole-bootstrap00
+#         - op: replace
+#           path: /spec/template/spec/containers/0/args
+#           value:
+#             - --source=service
+#             - --source=ingress
+#             # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+#             # You don't need to set this flag, but if you leave it unset, you will receive warning
+#             # logs when ExternalDNS attempts to create TXT records.
+#             - --registry=noop
+#             # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+#             # the policy to upsert-only so they do not get deleted.
+#             - --policy=upsert-only
+#             - --provider=pihole
+#             # Switch to pihole V6 API
+#             - --pihole-api-version=6
+#             # Change this to the actual address of your Pi-hole web server
+#             - --pihole-server=${piholeUrlMgmtBootstrap00}
+#             # - --pihole-tls-skip-verify
+#         - op: add
+#           path: /spec/template/spec/containers/0/envFrom
+#           value:
+#             - secretRef:
+#                 # Change this if you gave the secret a different name
+#                 name: pihole-password
+#       target:
+#         kind: Deployment
+#         name: external-dns

--- a/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-bootstrap00.yaml
+++ b/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-bootstrap00.yaml
@@ -3,7 +3,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: external-dns-pihole-bootstrap00
-  namespace: kube-system
+  namespace: cert-manager
 spec:
   interval: 5m
   chart:

--- a/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-k8s00.yaml
+++ b/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-k8s00.yaml
@@ -1,49 +1,99 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
 metadata:
   name: external-dns-pihole-k8s00
-  namespace: cert-manager
+  namespace: kube-system
 spec:
-  interval: 1440m
-  retryInterval: 1m
-  timeout: 5m
-  sourceRef:
-    kind: GitRepository
-    name: external-dns
-  path: ./kustomize
-  targetNamespace: cert-manager
-  prune: true
-  wait: true
-  patches:
-    - patch: |
-        - op: replace
-          path: /metadata/name
-          value: external-dns-pihole-k8s00
-        - op: replace
-          path: /spec/template/spec/containers/0/args
-          value:
-            - --source=service
-            - --source=ingress
-            # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
-            # You don't need to set this flag, but if you leave it unset, you will receive warning
-            # logs when ExternalDNS attempts to create TXT records.
-            - --registry=noop
-            # IMPORTANT: If you have records that you manage manually in Pi-hole, set
-            # the policy to upsert-only so they do not get deleted.
-            - --policy=upsert-only
-            - --provider=pihole
-            # Switch to pihole V6 API
-            - --pihole-api-version=6
-            # Change this to the actual address of your Pi-hole web server
-            - --pihole-server=${piholeUrlMgmtK8s00}
-            # - --pihole-tls-skip-verify
-        - op: add
-          path: /spec/template/spec/containers/0/envFrom
-          value:
-            - secretRef:
-                # Change this if you gave the secret a different name
-                name: pihole-password
-      target:
-        kind: Deployment
+  interval: 5m
+  chart:
+    spec:
+      chart: external-dns
+      version: ">=1.21.1 <1.22.0"
+      sourceRef:
+        kind: HelmRepository
         name: external-dns
+        namespace: cert-manager
+      interval: 1m
+  values:
+    env:
+      - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: EXTERNAL_DNS_PIHOLE_PASSWORD
+            name: pihole-password
+    extraArgs:
+      - --pihole-api-version=6
+      - --pihole-server=${piholeUrlMgmtK8s00}
+      - --pihole-tls-skip-verify
+    interval: 1m
+    namespaced: false
+    # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+    # the policy to upsert-only so they do not get deleted.
+    policy: upsert-only
+    provider:
+      name: pihole
+    # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+    # You don't need to set this flag, but if you leave it unset, you will receive warning
+    # logs when ExternalDNS attempts to create TXT records.
+    registry: noop
+    replicaCount: 1
+    service:
+      enabled: true
+      ipFamilies: []
+      ipFamilyPolicy: null
+    serviceMonitor:
+      enabled: false
+    sources:
+      - service
+      - ingress
+      # - gateway-httproute
+---
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: external-dns-pihole-k8s00
+#   namespace: cert-manager
+# spec:
+#   interval: 1440m
+#   retryInterval: 1m
+#   timeout: 5m
+#   sourceRef:
+#     kind: GitRepository
+#     name: external-dns
+#   path: ./kustomize
+#   targetNamespace: cert-manager
+#   prune: true
+#   wait: true
+#   patches:
+#     - patch: |
+#         - op: replace
+#           path: /metadata/name
+#           value: external-dns-pihole-k8s00
+#         - op: replace
+#           path: /spec/template/spec/containers/0/args
+#           value:
+#             - --source=service
+#             - --source=ingress
+#             # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+#             # You don't need to set this flag, but if you leave it unset, you will receive warning
+#             # logs when ExternalDNS attempts to create TXT records.
+#             - --registry=noop
+#             # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+#             # the policy to upsert-only so they do not get deleted.
+#             - --policy=upsert-only
+#             - --provider=pihole
+#             # Switch to pihole V6 API
+#             - --pihole-api-version=6
+#             # Change this to the actual address of your Pi-hole web server
+#             - --pihole-server=${piholeUrlMgmtK8s00}
+#             # - --pihole-tls-skip-verify
+#         - op: add
+#           path: /spec/template/spec/containers/0/envFrom
+#           value:
+#             - secretRef:
+#                 # Change this if you gave the secret a different name
+#                 name: pihole-password
+#       target:
+#         kind: Deployment
+#         name: external-dns

--- a/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-k8s00.yaml
+++ b/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-k8s00.yaml
@@ -3,7 +3,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: external-dns-pihole-k8s00
-  namespace: kube-system
+  namespace: cert-manager
 spec:
   interval: 5m
   chart:


### PR DESCRIPTION
This pull request migrates the deployment of ExternalDNS for Pi-hole integration from using Flux Kustomizations to HelmReleases managed by Flux. It also introduces a HelmRepository resource for the ExternalDNS Helm chart, and updates configuration to better align with Helm best practices and Pi-hole requirements.

**Migration to HelmRelease and HelmRepository:**

* Replaces existing `Kustomization` resources with `HelmRelease` resources for ExternalDNS deployments targeting Pi-hole in both `bootstrap00` and `k8s00` clusters. This enables direct management and upgrades via Helm, simplifying deployment and configuration. [[1]](diffhunk://#diff-00f06fb9b0c50e252b1711271f0ddd94ae01e1cde3111b8f9aad3ff70f292745L2-R99) [[2]](diffhunk://#diff-1d281356982cb0e51b9367d2f2dcd5621a7271544f80578dfceb35d882055c13L2-R99) [[3]](diffhunk://#diff-f5ad6522e9da89c405bb5c01d1bf3592c51b352061c306c294823964c1429bc0R2-R51)

* Adds a new `HelmRepository` resource (`external-dns`) in the `cert-manager` namespace, pointing to the official ExternalDNS Helm chart repository. This allows HelmReleases to source the chart directly.

**Configuration and Best Practices Improvements:**

* Updates ExternalDNS configuration to use Helm values (e.g., `extraArgs`, `env`, `provider`, `policy`, `registry`, etc.), ensuring secure handling of secrets, correct Pi-hole API usage, and recommended operational flags. [[1]](diffhunk://#diff-00f06fb9b0c50e252b1711271f0ddd94ae01e1cde3111b8f9aad3ff70f292745L2-R99) [[2]](diffhunk://#diff-1d281356982cb0e51b9367d2f2dcd5621a7271544f80578dfceb35d882055c13L2-R99) [[3]](diffhunk://#diff-f5ad6522e9da89c405bb5c01d1bf3592c51b352061c306c294823964c1429bc0R2-R51)

* Sets deployment intervals and chart version constraints for more predictable and controlled upgrades and reconciliations. [[1]](diffhunk://#diff-00f06fb9b0c50e252b1711271f0ddd94ae01e1cde3111b8f9aad3ff70f292745L2-R99) [[2]](diffhunk://#diff-1d281356982cb0e51b9367d2f2dcd5621a7271544f80578dfceb35d882055c13L2-R99) [[3]](diffhunk://#diff-f5ad6522e9da89c405bb5c01d1bf3592c51b352061c306c294823964c1429bc0R2-R51)

* Comments out the old Kustomization manifests for reference, making it easier to track the migration and revert if necessary. [[1]](diffhunk://#diff-00f06fb9b0c50e252b1711271f0ddd94ae01e1cde3111b8f9aad3ff70f292745L2-R99) [[2]](diffhunk://#diff-1d281356982cb0e51b9367d2f2dcd5621a7271544f80578dfceb35d882055c13L2-R99)

These changes modernize the deployment approach, improve maintainability, and ensure secure and reliable integration between ExternalDNS and Pi-hole.

**References:**  
[[1]](diffhunk://#diff-00f06fb9b0c50e252b1711271f0ddd94ae01e1cde3111b8f9aad3ff70f292745L2-R99) [[2]](diffhunk://#diff-1d281356982cb0e51b9367d2f2dcd5621a7271544f80578dfceb35d882055c13L2-R99) [[3]](diffhunk://#diff-f5ad6522e9da89c405bb5c01d1bf3592c51b352061c306c294823964c1429bc0R2-R51) [[4]](diffhunk://#diff-7c7bb117509267660e20c4bf15dbc502e88cfa2931aef16546346f460744a23fR1-R9)