### PR TITLE
fix: bootstrap00: external-dns: comment k8s00 kustomization

### DIFF
--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-k8s00.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-k8s00.yaml
@@ -49,51 +49,51 @@ spec:
       - ingress
       # - gateway-httproute
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: external-dns-pihole-k8s00
-  namespace: cert-manager
-spec:
-  interval: 1440m
-  retryInterval: 1m
-  timeout: 5m
-  sourceRef:
-    kind: GitRepository
-    name: external-dns
-  path: ./kustomize
-  targetNamespace: cert-manager
-  prune: true
-  wait: true
-  patches:
-    - patch: |
-        - op: replace
-          path: /metadata/name
-          value: external-dns-pihole-k8s00
-        - op: replace
-          path: /spec/template/spec/containers/0/args
-          value:
-            - --source=service
-            - --source=ingress
-            # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
-            # You don't need to set this flag, but if you leave it unset, you will receive warning
-            # logs when ExternalDNS attempts to create TXT records.
-            - --registry=noop
-            # IMPORTANT: If you have records that you manage manually in Pi-hole, set
-            # the policy to upsert-only so they do not get deleted.
-            - --policy=upsert-only
-            - --provider=pihole
-            # Switch to pihole V6 API
-            - --pihole-api-version=6
-            # Change this to the actual address of your Pi-hole web server
-            - --pihole-server=${piholeUrlMgmtK8s00}
-            # - --pihole-tls-skip-verify
-        - op: add
-          path: /spec/template/spec/containers/0/envFrom
-          value:
-            - secretRef:
-                # Change this if you gave the secret a different name
-                name: pihole-password
-      target:
-        kind: Deployment
-        name: external-dns
+# apiVersion: kustomize.toolkit.fluxcd.io/v1
+# kind: Kustomization
+# metadata:
+#   name: external-dns-pihole-k8s00
+#   namespace: cert-manager
+# spec:
+#   interval: 1440m
+#   retryInterval: 1m
+#   timeout: 5m
+#   sourceRef:
+#     kind: GitRepository
+#     name: external-dns
+#   path: ./kustomize
+#   targetNamespace: cert-manager
+#   prune: true
+#   wait: true
+#   patches:
+#     - patch: |
+#         - op: replace
+#           path: /metadata/name
+#           value: external-dns-pihole-k8s00
+#         - op: replace
+#           path: /spec/template/spec/containers/0/args
+#           value:
+#             - --source=service
+#             - --source=ingress
+#             # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+#             # You don't need to set this flag, but if you leave it unset, you will receive warning
+#             # logs when ExternalDNS attempts to create TXT records.
+#             - --registry=noop
+#             # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+#             # the policy to upsert-only so they do not get deleted.
+#             - --policy=upsert-only
+#             - --provider=pihole
+#             # Switch to pihole V6 API
+#             - --pihole-api-version=6
+#             # Change this to the actual address of your Pi-hole web server
+#             - --pihole-server=${piholeUrlMgmtK8s00}
+#             # - --pihole-tls-skip-verify
+#         - op: add
+#           path: /spec/template/spec/containers/0/envFrom
+#           value:
+#             - secretRef:
+#                 # Change this if you gave the secret a different name
+#                 name: pihole-password
+#       target:
+#         kind: Deployment
+#         name: external-dns


### PR DESCRIPTION
This pull request comments out the entire `Kustomization` resource configuration for `external-dns-pihole-k8s00` in the `external-dns-pihole-k8s00.yaml` file. This effectively disables the deployment and management of the ExternalDNS integration with Pi-hole for the `k8s00` cluster without deleting the configuration, making it easy to restore later if needed.

Configuration changes:

* Commented out the full `Kustomization` resource definition in `external-dns-pihole-k8s00.yaml`, disabling the automated deployment and patching of the `external-dns` Pi-hole integration in the `cert-manager` namespace.