### PR TITLE
fix: k8s00 and bootstrap00: external-dns: https to http for internal …

### DIFF
--- a/kubernetes/clusters/bootstrap00/global.values.sops.yaml
+++ b/kubernetes/clusters/bootstrap00/global.values.sops.yaml
@@ -29,7 +29,7 @@ stringData:
   ingressMgmtIpv4: ENC[AES256_GCM,data:oqTAgXc7UjhaTNA=,iv:ASdTCggZR5eY7GmyfXb5kDDcRNbhKBfowGVCPPMX4Io=,tag:2jKUDi9jc6K6NO+hiumfbQ==,type:str]
   ingressMgmtIpv6: ENC[AES256_GCM,data:Mov6U8XW8QZ+06yp8E2GJq+AclIcIw==,iv:euM/iPdAh4lCUYuOxbT/CDcqa3+YO9KLtZx6S5Wmatg=,tag:DCO0PN9J2+BwHXYJFnvDVg==,type:str]
   piholeUrlMgmtBootstrap00: ENC[AES256_GCM,data:VIe7K8xckEGAgOSK1kWqDfjjnOabKg89tQijPEWcb1nAaDrtgI2Wjp/zjcpN0a/Xqw==,iv:c1UfUlD/Uau43X3tvbS9owUbl+tUc/m74kdYEKmjssY=,tag:N1dkjQyu76LYWAkcaOeGEQ==,type:str]
-  piholeUrlMgmtBootstrap00Internal: ENC[AES256_GCM,data:2vEzrxPcgh/ZNh+a7ou8lNdJ5tOtsC6JHFVvU4g8,iv:HHXuKUtAQ1rYOFDVe6Lc07cOuwjyblDwzGItzF8ZJx4=,tag:H9Z/45rGD9JFRZQoA/05Vg==,type:str]
+  piholeUrlMgmtBootstrap00Internal: ENC[AES256_GCM,data:6T8dubujfV6NKpRUECg94kKD79/3N7/Vg3l2/Lc=,iv:MBGUsek03GT/DY8wvoqbsoPTzWT4aUiM6xlcyps7zUw=,tag:559lz+Iw7n39tBH4D8ydbw==,type:str]
   piholeUrlMgmtK8s00: ENC[AES256_GCM,data:vBTyBpVbG1eMu20Zr9/Yi9Irs+1tyQPQIJZ9zZUC9DSzCeX1tT/SbT68pA==,iv:Ut1seW85ri1ecvopE2GNAZjswcS7NoqESEBl/JnkH8Y=,tag:rmFePYUD9pV/3E0XddyMIA==,type:str]
   piholeIpv4MgmtBootstrap00: ENC[AES256_GCM,data:9q6rYLgcAvwTG3s=,iv:v27MCPy4bsORTnjS/UHARKYghdvcRpkHVCGUvjR4Onc=,tag:J3O2gcsqX6u5Y4JDeX1h1g==,type:str]
   piholeIpv6MgmtBootstrap00: ENC[AES256_GCM,data:8ijR1ziX9a3k4xdS91lKQ4eI/tJ2Mg==,iv:Ry8tS3fx2jNkqr1UxqJcdsL7ykJes0JReuTkZXr8PH8=,tag:M5xgd3IwGjXLZ+q1OONg7g==,type:str]
@@ -55,6 +55,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-24T21:18:31Z"
-  mac: ENC[AES256_GCM,data:Fx/Jg1hDVDfyC1qisfoxaGx04yWd1LHWG8C+II7yDyt6BAycoVj1L8FK0fy4zfXKXkGGACEzaFxMYe6WTba7udAIPGorOpypRFZLu5Lgosi0E2X7h2oymWJl9zjtmUEzkICBCauG9ouN5rKIEJXb1ZDO8XHxz448nFhY0gwbtlU=,iv:W+uBO2bAoxFDIxQbSpEnbiaOMmri89wrKB4Ot0PJRpE=,tag:YR4FrfEmDqmKogoO+fV7/g==,type:str]
+  lastmodified: "2026-06-24T21:34:47Z"
+  mac: ENC[AES256_GCM,data:RgmrLJndvUECVrr7rZ4kUSAnaLpFugQ7+igOGbA3tmMBUQLiRtbXf2/Lszw2pACTuPdd6N2W2GuFDCB7ucjDIVFIRNPnsLAKfg/sLtAl329AYZQcMeZv1aex+MVsv2XCaCNldfHTktWfgfBa0IcNnTx6CkAwwVmjRrxA4IhJ7Dk=,iv:4PUNShaoVP2iVG/s8Q40cPAycJ++sCEOnTq+70EMiXE=,tag:amAwNen2CFhXSzcNgQYJ6w==,type:str]
   version: 3.13.1

--- a/kubernetes/clusters/k8s00/global.variables.sops.yaml
+++ b/kubernetes/clusters/k8s00/global.variables.sops.yaml
@@ -24,7 +24,7 @@ stringData:
   k8s00DomainOld: ENC[AES256_GCM,data:lyi5BW26g0cENmtxBYp1VVJR0Q==,iv:gesiXsL9VXLUUHzDz8PPzYDdn1hcf6jVGHH+iHEbSbY=,tag:qYJ2bGdWlzAGvBYxUsjJuA==,type:str]
   piholeUrlMgmtBootstrap00: ENC[AES256_GCM,data:qoKSxZ3jR9xrVMcEEawoyYyrG1WdJStNvS0lv/SGhH9iTsu/d+i8djHmgA/uns14DQ==,iv:L1apPtbzs5SmIUqONf+mUYDmoQ3u8OaWkZJJptZNmvE=,tag:REFcTM1XRFMJ/OKoBOlONw==,type:str]
   piholeUrlMgmtK8s00: ENC[AES256_GCM,data:dwf+sFV8DXiyEhLcuO2Vj+E01oGZthDkI7oEFyu4Uxssq1wbXyjW0dFIGQ==,iv:XY7N2LvnF4yxr52PqQr9tpiXQAM9Ezz+tW62hSpywPU=,tag:jK2Vt5ZkkEWGFeE4x9H1mQ==,type:str]
-  piholeUrlMgmtK8s00Internal: ENC[AES256_GCM,data:SOUhF/mNhAZTFrMHt752dRYtOeTWPKhEgqyJvqtx,iv:P3Phb/k5GfDKZfcI9s4MOTVRJ7T08OwvaHFjnrbR0uo=,tag:m0ajjrONAWNVwOdC9JIbMg==,type:str]
+  piholeUrlMgmtK8s00Internal: ENC[AES256_GCM,data:6VC2rihMJhFabrc7NtheCQumnCBoJK7+rmQ8dwA=,iv:Xp4O8fGN7Qe6FugBtBbpwURFSEmYOUQraXJceEAM2fM=,tag:CjwuIvSpeMmVk3lX8vMdJA==,type:str]
   piholeIpv4MgmtK8s00: ENC[AES256_GCM,data:UC62pO440tQlnBo=,iv:unentwg99dzrqsr+kmd4SsDCTRWkH0QwMwaBksnfWGw=,tag:Ybj1gulfHlZ/BKiQYia0/w==,type:str]
   piholeIpv6MgmtK8s00: ENC[AES256_GCM,data:RcX1j8cKRY9+j23soeytMXbtmmFuwA==,iv:IJzNxmT0fFsz725hQgIG8AZ0TPCfI2L+/jq9hr7YzZk=,tag:ZJ+xgm1LDRRWB3isXpc+Aw==,type:str]
   piholeIpv4K8s00Bootstrap00: ENC[AES256_GCM,data:qfBxfyr+pU5NJRfu,iv:kW84pgfnp/D7s7bXcz43ALR/NzH61NOU5poYDlRiEVA=,tag:Z2vxhGtK5qlQVyX3EWig8Q==,type:str]
@@ -49,6 +49,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-24T21:18:23Z"
-  mac: ENC[AES256_GCM,data:re6UOLtBDqk2IGWcWxY+ArmTeix7qjKSctRHJN1fJLiuLLGKQOPHU3fgy9vsrUODbnm4X2duvjaAzBrrKYlLXqNCeuiO8n65fZdRH1IwZ3wjaXS+le8F9U4t4TK9Zcbr5RWOtLYV7eCFCgHJeYcyTxFjlsi8bZ+Ja8t/PJ5ATAo=,iv:s+HRhwaf7g44xxSIlaAxtAudyg2nb5zTeEbQpUxJjdE=,tag:jdIpTXmYm21acm2M2FrCuQ==,type:str]
+  lastmodified: "2026-06-24T21:34:32Z"
+  mac: ENC[AES256_GCM,data:yeN6rL0y+anYD/vjIS7Pjo0IgmArdxVew3hTvyr7ytBK3fPdRUIkh9zBAe0PDzycSe6ARKP0EypMoDMf1jgzxEUi98mJXXKRNU+WmFYWJATb5pJ/CX0CHe8ho1Du7TscP04TsvXqibyl/uCX4Yk6fuavKWvCXdLFqXlLlJ6Sfas=,iv:8n+ptdhBUhhfn+jLeCCEf6wKswmIyIhdg9+r/XCsU6c=,tag:9P1kZ5lcjE+CkhHTWDZKIA==,type:str]
   version: 3.13.1

--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-mgmt-bootstrap00.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-mgmt-bootstrap00.yaml
@@ -25,7 +25,6 @@ spec:
     extraArgs:
       - --pihole-api-version=6
       - --pihole-server=${piholeUrlMgmtBootstrap00Internal}
-      - --pihole-tls-skip-verify
     interval: 1m
     namespaced: false
     # IMPORTANT: If you have records that you manage manually in Pi-hole, set

--- a/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-mgmt-k8s00.yaml
+++ b/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-mgmt-k8s00.yaml
@@ -25,7 +25,6 @@ spec:
     extraArgs:
       - --pihole-api-version=6
       - --pihole-server=${piholeUrlMgmtK8s00Internal}
-      - --pihole-tls-skip-verify
     interval: 1m
     namespaced: false
     # IMPORTANT: If you have records that you manage manually in Pi-hole, set


### PR DESCRIPTION
This pull request updates encrypted Pi-hole internal URLs in both the `bootstrap00` and `k8s00` clusters and removes the `--pihole-tls-skip-verify` flag from their respective `external-dns` configurations. These changes improve the security and consistency of DNS management across clusters.

**Encrypted secrets updates:**

* Updated the encrypted value for `piholeUrlMgmtBootstrap00Internal` in `kubernetes/clusters/bootstrap00/global.values.sops.yaml`, and refreshed the SOPS metadata (`lastmodified`, `mac`). [[1]](diffhunk://#diff-28a8f6cdd841b219e537df086be2dee093c292f88cac4b68ccf0cb309592b6bfL32-R32) [[2]](diffhunk://#diff-28a8f6cdd841b219e537df086be2dee093c292f88cac4b68ccf0cb309592b6bfL58-R59)
* Updated the encrypted value for `piholeUrlMgmtK8s00Internal` in `kubernetes/clusters/k8s00/global.variables.sops.yaml`, and refreshed the SOPS metadata (`lastmodified`, `mac`). [[1]](diffhunk://#diff-a1864963c08f069e3d37bdaac3d9525655e0bf861d58537f3c8b76d984ed2f87L27-R27) [[2]](diffhunk://#diff-a1864963c08f069e3d37bdaac3d9525655e0bf861d58537f3c8b76d984ed2f87L52-R53)

**External DNS configuration changes:**

* Removed the `--pihole-tls-skip-verify` argument from the `external-dns` deployment for both `bootstrap00` and `k8s00` clusters, enforcing TLS certificate verification on Pi-hole API connections. [[1]](diffhunk://#diff-803b99fec29a8bdb951593873f24ce6f8ac605eaeaa20f153c11b6e1bea20b1bL28) [[2]](diffhunk://#diff-8d348145a1607db9a6a37da9b3b23577644f3de7cadc940935fa2166afbeb4b8L28)…call