### PR TITLE
feat: k8s00 and bootstrap00: external-dns: multiple changes

### DIFF
--- a/kubernetes/clusters/k8s00/global.variables.sops.yaml
+++ b/kubernetes/clusters/k8s00/global.variables.sops.yaml
@@ -25,6 +25,8 @@ stringData:
   piholeUrlMgmtBootstrap00: ENC[AES256_GCM,data:qoKSxZ3jR9xrVMcEEawoyYyrG1WdJStNvS0lv/SGhH9iTsu/d+i8djHmgA/uns14DQ==,iv:L1apPtbzs5SmIUqONf+mUYDmoQ3u8OaWkZJJptZNmvE=,tag:REFcTM1XRFMJ/OKoBOlONw==,type:str]
   piholeUrlMgmtK8s00: ENC[AES256_GCM,data:dwf+sFV8DXiyEhLcuO2Vj+E01oGZthDkI7oEFyu4Uxssq1wbXyjW0dFIGQ==,iv:XY7N2LvnF4yxr52PqQr9tpiXQAM9Ezz+tW62hSpywPU=,tag:jK2Vt5ZkkEWGFeE4x9H1mQ==,type:str]
   piholeUrlMgmtK8s00Internal: ENC[AES256_GCM,data:6VC2rihMJhFabrc7NtheCQumnCBoJK7+rmQ8dwA=,iv:Xp4O8fGN7Qe6FugBtBbpwURFSEmYOUQraXJceEAM2fM=,tag:CjwuIvSpeMmVk3lX8vMdJA==,type:str]
+  piholeUrlK8s00Bootstrap00: ENC[AES256_GCM,data:NmyGE5grJY8ExRYNcqt59+zAEnjc/98G0cqHX5pY41VMop6rwtErXuAKTnz+L8DQjN0=,iv:aw/61XbCmn2oY8AGbkB7vkM1odMw/NnnqgZXrycBdAo=,tag:Lrwws474/Wqj5g+IwVQ9gw==,type:str]
+  piholeUrlK8s00K8s00Internal: ENC[AES256_GCM,data:FTCI+8hsk+sgxv3ymXeprp2KJbiDsKmZ4b9cqXnH,iv:JDVy9CL2ZsUlfX34+gbBTC/D+vVNWALnExwdoSqjJIk=,tag:2VyE+OSvNAY9zUD7iLjDpw==,type:str]
   piholeIpv4MgmtK8s00: ENC[AES256_GCM,data:UC62pO440tQlnBo=,iv:unentwg99dzrqsr+kmd4SsDCTRWkH0QwMwaBksnfWGw=,tag:Ybj1gulfHlZ/BKiQYia0/w==,type:str]
   piholeIpv6MgmtK8s00: ENC[AES256_GCM,data:RcX1j8cKRY9+j23soeytMXbtmmFuwA==,iv:IJzNxmT0fFsz725hQgIG8AZ0TPCfI2L+/jq9hr7YzZk=,tag:ZJ+xgm1LDRRWB3isXpc+Aw==,type:str]
   piholeIpv4K8s00Bootstrap00: ENC[AES256_GCM,data:qfBxfyr+pU5NJRfu,iv:kW84pgfnp/D7s7bXcz43ALR/NzH61NOU5poYDlRiEVA=,tag:Z2vxhGtK5qlQVyX3EWig8Q==,type:str]
@@ -49,6 +51,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-24T21:34:32Z"
-  mac: ENC[AES256_GCM,data:yeN6rL0y+anYD/vjIS7Pjo0IgmArdxVew3hTvyr7ytBK3fPdRUIkh9zBAe0PDzycSe6ARKP0EypMoDMf1jgzxEUi98mJXXKRNU+WmFYWJATb5pJ/CX0CHe8ho1Du7TscP04TsvXqibyl/uCX4Yk6fuavKWvCXdLFqXlLlJ6Sfas=,iv:8n+ptdhBUhhfn+jLeCCEf6wKswmIyIhdg9+r/XCsU6c=,tag:9P1kZ5lcjE+CkhHTWDZKIA==,type:str]
+  lastmodified: "2026-06-24T22:06:50Z"
+  mac: ENC[AES256_GCM,data:SrIOIGNKZ3h67d5nHBUeDAAaZct1yPmRwgxeZSfiP8OvMh6kavuqYRm5LVu2kMRnPP9lucenWaLwHdgsDllbFHffNGf6bW21Zr11GqNGwd0WmUY+aTNfDFPSOG2+mB0/i7N8sIrWsQZ9WfUHbyWeYQlevWyDUtsRuKjUT0IBlUA=,iv:2Gf3/VhArkIANzx57tKwgME+4acSZv65V1fq3shvNUg=,tag:uKEf7Zk5INxODKl+h1VpYQ==,type:str]
   version: 3.13.1

--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-bootstrap00.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-bootstrap00.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: external-dns-pihole-bootstrap00
+  name: external-dns-pihole-mgmt-bootstrap00
   namespace: cert-manager
 spec:
   interval: 5m
@@ -16,6 +16,9 @@ spec:
         namespace: cert-manager
       interval: 1m
   values:
+    domainFilters:
+      - ${mgmtDomainOld}
+      - ${mgmtDomain}
     env:
       - name: EXTERNAL_DNS_PIHOLE_PASSWORD
         valueFrom:
@@ -24,8 +27,7 @@ spec:
             name: pihole-password
     extraArgs:
       - --pihole-api-version=6
-      - --pihole-server=${piholeUrlMgmtBootstrap00}
-      - --pihole-tls-skip-verify
+      - --pihole-server=${piholeUrlMgmtBootstrap00Internal}
     interval: 1m
     namespaced: false
     # IMPORTANT: If you have records that you manage manually in Pi-hole, set

--- a/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-k8s00.yaml
+++ b/kubernetes/infrastructure/bootstrap00/external-dns/external-dns-pihole-k8s00.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: external-dns-pihole-k8s00
+  name: external-dns-pihole-mgmt-k8s00
   namespace: cert-manager
 spec:
   interval: 5m
@@ -16,6 +16,9 @@ spec:
         namespace: cert-manager
       interval: 1m
   values:
+    domainFilters:
+      - ${mgmtDomainOld}
+      - ${mgmtDomain}
     env:
       - name: EXTERNAL_DNS_PIHOLE_PASSWORD
         valueFrom:
@@ -24,7 +27,8 @@ spec:
             name: pihole-password
     extraArgs:
       - --pihole-api-version=6
-      - --pihole-server=${piholeUrlMgmtK8s00Internal}
+      - --pihole-server=${piholeUrlMgmtK8s00}
+      - --pihole-tls-skip-verify
     interval: 1m
     namespaced: false
     # IMPORTANT: If you have records that you manage manually in Pi-hole, set

--- a/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-bootstrap00.yaml
+++ b/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-bootstrap00.yaml
@@ -16,6 +16,9 @@ spec:
         namespace: cert-manager
       interval: 1m
   values:
+    domainFilters:
+      - ${mgmtDomainOld}
+      - ${mgmtDomain}
     env:
       - name: EXTERNAL_DNS_PIHOLE_PASSWORD
         valueFrom:
@@ -24,7 +27,63 @@ spec:
             name: pihole-password
     extraArgs:
       - --pihole-api-version=6
-      - --pihole-server=${piholeUrlMgmtBootstrap00Internal}
+      - --pihole-server=${piholeUrlMgmtBootstrap00}
+      - --pihole-tls-skip-verify
+    interval: 1m
+    namespaced: false
+    # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+    # the policy to upsert-only so they do not get deleted.
+    policy: upsert-only
+    provider:
+      name: pihole
+    # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+    # You don't need to set this flag, but if you leave it unset, you will receive warning
+    # logs when ExternalDNS attempts to create TXT records.
+    registry: noop
+    replicaCount: 1
+    service:
+      enabled: true
+      ipFamilies: []
+      ipFamilyPolicy: null
+    serviceMonitor:
+      enabled: false
+    sources:
+      - service
+      - ingress
+      # - gateway-httproute
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns-pihole-k8s00-bootstrap00
+  namespace: cert-manager
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: external-dns
+      version: ">=1.21.1 <1.22.0"
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: cert-manager
+      interval: 1m
+  values:
+    domainFilters:
+      - ${serviceDomainOld}
+      - ${serviceDomain}
+      - service.${k8s00DomainOld}
+      - service.${k8s00Domain}
+    env:
+      - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: EXTERNAL_DNS_PIHOLE_PASSWORD
+            name: pihole-password
+    extraArgs:
+      - --pihole-api-version=6
+      - --pihole-server=${piholeUrlK8s00Bootstrap00}
+      - --pihole-tls-skip-verify
     interval: 1m
     namespaced: false
     # IMPORTANT: If you have records that you manage manually in Pi-hole, set

--- a/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-k8s00.yaml
+++ b/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-k8s00.yaml
@@ -16,6 +16,9 @@ spec:
         namespace: cert-manager
       interval: 1m
   values:
+    domainFilters:
+      - ${mgmtDomainOld}
+      - ${mgmtDomain}
     env:
       - name: EXTERNAL_DNS_PIHOLE_PASSWORD
         valueFrom:
@@ -24,8 +27,61 @@ spec:
             name: pihole-password
     extraArgs:
       - --pihole-api-version=6
-      - --pihole-server=${piholeUrlMgmtK8s00}
-      - --pihole-tls-skip-verify
+      - --pihole-server=${piholeUrlMgmtK8s00Internal}
+    interval: 1m
+    namespaced: false
+    # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+    # the policy to upsert-only so they do not get deleted.
+    policy: upsert-only
+    provider:
+      name: pihole
+    # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+    # You don't need to set this flag, but if you leave it unset, you will receive warning
+    # logs when ExternalDNS attempts to create TXT records.
+    registry: noop
+    replicaCount: 1
+    service:
+      enabled: true
+      ipFamilies: []
+      ipFamilyPolicy: null
+    serviceMonitor:
+      enabled: false
+    sources:
+      - service
+      - ingress
+      # - gateway-httproute
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns-pihole-k8s00-k8s00
+  namespace: cert-manager
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: external-dns
+      version: ">=1.21.1 <1.22.0"
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: cert-manager
+      interval: 1m
+  values:
+    domainFilters:
+      - ${serviceDomainOld}
+      - ${serviceDomain}
+      - service.${k8s00DomainOld}
+      - service.${k8s00Domain}
+    env:
+      - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: EXTERNAL_DNS_PIHOLE_PASSWORD
+            name: pihole-password
+    extraArgs:
+      - --pihole-api-version=6
+      - --pihole-server=${piholeUrlK8s00K8s00Internal}
     interval: 1m
     namespaced: false
     # IMPORTANT: If you have records that you manage manually in Pi-hole, set


### PR DESCRIPTION
This pull request introduces new ExternalDNS HelmRelease resources for Pi-hole DNS management in the `bootstrap00` and `k8s00` clusters, and updates existing configurations to support both management and service domains. It also adds new encrypted variables for Pi-hole URLs and updates SOPS metadata.

**ExternalDNS HelmRelease enhancements and additions:**

* Added new HelmRelease resources `external-dns-pihole-k8s00-bootstrap00` and `external-dns-pihole-k8s00-k8s00` to manage DNS records for service domains in both the `bootstrap00` and `k8s00` clusters. These releases include domain filters for service domains, updated environment variables, and specific Pi-hole server URLs. [[1]](diffhunk://#diff-698d19675348778277b96816c03ef532c9c64af834085d55c8122cc6894deb5dR55-R109) [[2]](diffhunk://#diff-1d281356982cb0e51b9367d2f2dcd5621a7271544f80578dfceb35d882055c13R54-R107)
* Updated existing HelmRelease resources (`external-dns-pihole-mgmt-bootstrap00` and `external-dns-pihole-mgmt-k8s00`) to include `domainFilters` for management domains, supporting both old and new domain formats. [[1]](diffhunk://#diff-00f06fb9b0c50e252b1711271f0ddd94ae01e1cde3111b8f9aad3ff70f292745R19-R21) [[2]](diffhunk://#diff-f5ad6522e9da89c405bb5c01d1bf3592c51b352061c306c294823964c1429bc0R19-R21) [[3]](diffhunk://#diff-698d19675348778277b96816c03ef532c9c64af834085d55c8122cc6894deb5dR19-R21) [[4]](diffhunk://#diff-1d281356982cb0e51b9367d2f2dcd5621a7271544f80578dfceb35d882055c13R19-R21)

**Resource renaming and configuration updates:**

* Renamed HelmRelease YAML files and resource names to distinguish between management and service domain responsibilities, clarifying the purpose of each resource. [[1]](diffhunk://#diff-698d19675348778277b96816c03ef532c9c64af834085d55c8122cc6894deb5dL5-R5) [[2]](diffhunk://#diff-1d281356982cb0e51b9367d2f2dcd5621a7271544f80578dfceb35d882055c13L5-R5)

**Secret management and encrypted variables:**

* Added new encrypted Pi-hole URL variables (`piholeUrlK8s00Bootstrap00`, `piholeUrlK8s00K8s00Internal`) to `global.variables.sops.yaml` for use by the new HelmRelease resources.
* Updated SOPS metadata (`lastmodified` and `mac`) to reflect the changes to encrypted secrets.