### PR TITLE
feat: bootstrap00: add pihole

### DIFF
--- a/kubernetes/apps/bootstrap00/namespace.yaml
+++ b/kubernetes/apps/bootstrap00/namespace.yaml
@@ -3,8 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: bootstrap
-# ---
-# apiVersion: v1
-# kind: Namespace
-# metadata:
-#   name: pihole
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pihole

--- a/kubernetes/apps/bootstrap00/pihole/helm-repo.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/helm-repo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: mojo2600
+  namespace: pihole
+spec:
+  interval: 1440m
+  url: https://mojo2600.github.io/pihole-kubernetes/

--- a/kubernetes/apps/bootstrap00/pihole/pihole-casa.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-casa.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pihole-casa
+  namespace: pihole
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: pihole
+      version: ">=2.36.0 <2.37"
+      sourceRef:
+        kind: HelmRepository
+        name: mojo2600
+        namespace: pihole
+      interval: 1m
+  values:
+    admin:
+      enabled: true
+      existingSecret: pihole
+      passwordKey: password
+    doh:
+      enabled: false
+    dualStack:
+      enabled: false
+    extraEnvVars:
+      FTLCONF_dns_listeningMode: 'all'
+    ftl:
+      dns_upstreams: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00};${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
+      dns_rateLimit_count: "100000"
+      dns_rateLimit_interval: "15"
+      ntp_ipv4_active: false
+      ntp_ipv6_active: false
+      webserver_interface_boxed: false
+      webserver_interface_theme: default-dark
+    ingress:
+      enabled: true
+      annotations:
+        cert-manager.io/cluster-issuer: homelab-internal
+      ingressClassName: nginx
+      hosts:
+        - piholecasa.bootstrap00.${mgmtDomainOld}
+      path: /
+      pathType: ImplementationSpecific
+      tls:
+        - hosts:
+            - piholecasa.bootstrap00.${mgmtDomainOld}
+          secretName: piholecasa.bootstrap00.${mgmtDomainOld}-tls
+    persistentVolumeClaim:
+      enabled: false
+      # size: 500Mi
+    serviceDhcp:
+      enabled: false
+    serviceDns:
+      type: ClusterIP
+    serviceWeb:
+      type: ClusterIP
+    strategyType: Recreate

--- a/kubernetes/apps/bootstrap00/pihole/pihole-k8s00.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-k8s00.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pihole-k8s00
+  namespace: pihole
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: pihole
+      version: ">=2.36.0 <2.37"
+      sourceRef:
+        kind: HelmRepository
+        name: mojo2600
+        namespace: pihole
+      interval: 1m
+  values:
+    admin:
+      enabled: true
+      existingSecret: pihole
+      passwordKey: password
+    doh:
+      enabled: false
+    dualStack:
+      enabled: false
+    extraEnvVars:
+      FTLCONF_dns_listeningMode: 'all'
+    ftl:
+      dns_upstreams: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00};${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
+      dns_rateLimit_count: "100000"
+      dns_rateLimit_interval: "15"
+      ntp_ipv4_active: false
+      ntp_ipv6_active: false
+      webserver_interface_boxed: false
+      webserver_interface_theme: default-dark
+    ingress:
+      enabled: true
+      annotations:
+        cert-manager.io/cluster-issuer: homelab-internal
+      ingressClassName: nginx
+      hosts:
+        - piholek8s00.bootstrap00.${mgmtDomainOld}
+      path: /
+      pathType: ImplementationSpecific
+      tls:
+        - hosts:
+            - piholek8s00.bootstrap00.${mgmtDomainOld}
+          secretName: piholek8s00.bootstrap00.${mgmtDomainOld}-tls
+    persistentVolumeClaim:
+      enabled: false
+      # size: 500Mi
+    serviceDhcp:
+      enabled: false
+    serviceDns:
+      type: ClusterIP
+    serviceWeb:
+      type: ClusterIP
+    strategyType: Recreate

--- a/kubernetes/apps/bootstrap00/pihole/pihole-mgmt.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-mgmt.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pihole-mgmt
+  namespace: pihole
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: pihole
+      version: ">=2.36.0 <2.37"
+      sourceRef:
+        kind: HelmRepository
+        name: mojo2600
+        namespace: pihole
+      interval: 1m
+  values:
+    admin:
+      enabled: true
+      existingSecret: pihole
+      passwordKey: password
+    dnsmasq:
+      customCnameEntries:
+        - cname=router.${mgmtDomainOld},router
+        - cname=router.${mgmtDomain},router
+        - cname=nas00.${mgmtDomainOld},nas00
+        - cname=nas00.${mgmtDomain},nas00
+      customDnsEntries:
+        - address=/router/${routerIpMgmt}
+        - address=/nas00/${nasIpmgmt}
+      enableCustomDnsMasq: true
+    doh:
+      enabled: false
+    dualStack:
+      enabled: true
+    extraEnvVars:
+      FTLCONF_dns_listeningMode: 'all'
+    ftl:
+      dns_upstreams: "${piholeIpv4K8s00Bootstrap00};${piholeIpv4K8s00K8s00};${piholeIpv6K8s00Bootstrap00};${piholeIpv6K8s00K8s00}"
+      dns_rateLimit_count: "100000"
+      dns_rateLimit_interval: "15"
+      ntp_ipv4_active: false
+      ntp_ipv6_active: false
+      webserver_interface_boxed: false
+      webserver_interface_theme: default-dark
+      misc_dnsmasq_lines: |-
+        server=/${mgmtDomainOld}/${routerIpMgmt}
+        server=/${mgmtDomain}/${routerIpMgmt}
+    ingress:
+      enabled: true
+      annotations:
+        cert-manager.io/cluster-issuer: homelab-internal
+      ingressClassName: nginx
+      hosts:
+        - piholemgmt.bootstrap00.${mgmtDomainOld}
+      path: /
+      pathType: ImplementationSpecific
+      tls:
+        - hosts:
+            - piholemgmt.bootstrap00.${mgmtDomainOld}
+          secretName: piholemgmt.bootstrap00.${mgmtDomainOld}-tls
+    persistentVolumeClaim:
+      enabled: false
+      # size: 500Mi
+    serviceDhcp:
+      enabled: false
+    serviceDns:
+      type: ClusterIP
+    serviceWeb:
+      type: ClusterIP
+    strategyType: Recreate

--- a/kubernetes/apps/bootstrap00/pihole/pihole-service.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-service.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pihole-service
+  namespace: pihole
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: pihole
+      version: ">=2.36.0 <2.37"
+      sourceRef:
+        kind: HelmRepository
+        name: mojo2600
+        namespace: pihole
+      interval: 1m
+  values:
+    DNS1: "${routerIpService}"
+    DNS2: "${routerIpService}#53053"
+    admin:
+      enabled: true
+      existingSecret: pihole
+      passwordKey: password
+    doh:
+      enabled: false
+    dualStack:
+      enabled: false
+    extraEnvVars:
+      FTLCONF_dns_listeningMode: 'all'
+    ftl:
+      dns_rateLimit_count: "100000"
+      dns_rateLimit_interval: "15"
+      ntp_ipv4_active: false
+      ntp_ipv6_active: false
+      webserver_interface_boxed: false
+      webserver_interface_theme: default-dark
+    ingress:
+      enabled: true
+      annotations:
+        cert-manager.io/cluster-issuer: homelab-internal
+      ingressClassName: nginx
+      hosts:
+        - piholeservice.bootstrap00.${mgmtDomainOld}
+      path: /
+      pathType: ImplementationSpecific
+      tls:
+        - hosts:
+            - piholeservice.bootstrap00.${mgmtDomainOld}
+          secretName: piholeservice.bootstrap00.${mgmtDomainOld}-tls
+    persistentVolumeClaim:
+      enabled: false
+      # size: 500Mi
+    serviceDhcp:
+      enabled: false
+    serviceDns:
+      type: ClusterIP
+    serviceWeb:
+      type: ClusterIP
+    strategyType: Recreate

--- a/kubernetes/apps/bootstrap00/pihole/pihole.secrets.sops.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole.secrets.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pihole
+  namespace: pihole
+stringData:
+  password: ENC[AES256_GCM,data:roMe2VL0cAKhjajkqjyZ,iv:Jqzc7823ZwyzIyc9vDq9vFcMw9DDdIs95Hdf1laSiwU=,tag:kfxOKYxqLWRHz7p/3LhkEw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1ZnRvbEFMR0d5bnk4ZGRs
+        NXBzNjYyNTlza3J6S1p1K0tZelRpZVd5L21rCkFKMFAyOTludG9IQVVnSEVzUlNT
+        NWloeEs1K0g0bTlCbmdMMzJzdlRLUWsKLS0tIEE3RVJ4UEJHN0ZWNEZEajVrYXVn
+        cEtCMGMxZkVWRlVNTlFURS9kSk41a2sK9F2y3WToLl33ooXI1W5oCMn9rVl1UqcA
+        BnyHeA8ZNPaWlMKB5gNU4djk9Vb46zj2sBEE+dFLcawMajK2v23JZg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-22T12:58:29Z"
+  mac: ENC[AES256_GCM,data:u9qfcBAYsIYQtyDfDR5dJOckIDE5gwlblgKyoz0951T9xx1RVXiOsNyJnJCvMjzmxbRwO73gxZbagHTZpQngXt0ZUwB+PZFvppUwXVP/WArqW92Zm39Ybsva4/vA5wgIpDn9VIAPCDdErLY4NsNdEm1YgYX/On7ZQTkzPD0+HBY=,iv:xKvTjq8JPO7jtq+oExdn+HDryPJc82XNyB2TtYdY+NU=,tag:JQR606U5DVnJGbdU7vVhJQ==,type:str]
+  version: 3.13.1

--- a/kubernetes/apps/bootstrap00/pihole/services.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/services.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-mgmt
+  namespace: pihole
+  labels:
+    app: pihole-mgmt
+    network: mgmt
+  annotations:
+    lbipam.cilium.io/ips: "${piholeIpv4MgmtBootstrap00},${piholeIpv6MgmtBootstrap00}"
+    lbipam.cilium.io/sharing-key: mgmt-pihole
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+  ports:
+    - name: dns
+      port: 53
+      protocol: TCP
+      targetPort: dns
+    - name: dns-udp
+      port: 53
+      protocol: UDP
+      targetPort: dns-udp
+  type: LoadBalancer
+  loadBalancerClass: io.cilium/bgp-control-plane
+  # loadBalancerClass: io.cilium/l2-announcer
+  selector:
+    app: pihole
+    release: pihole-mgmt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-service
+  namespace: pihole
+  labels:
+    app: pihole-service
+    network: service
+  annotations:
+    lbipam.cilium.io/ips: "${piholeIpv4ServiceBootstrap00},${piholeIpv6ServiceBootstrap00}"
+    lbipam.cilium.io/sharing-key: service-pihole
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+  ports:
+    - name: dns
+      port: 53
+      protocol: TCP
+      targetPort: dns
+    - name: dns-udp
+      port: 53
+      protocol: UDP
+      targetPort: dns-udp
+  type: LoadBalancer
+  loadBalancerClass: io.cilium/bgp-control-plane
+  # loadBalancerClass: io.cilium/l2-announcer
+  selector:
+    app: pihole
+    release: pihole-service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-casa
+  namespace: pihole
+  labels:
+    app: pihole-casa
+    network: casa
+  annotations:
+    lbipam.cilium.io/ips: "${piholeIpv4CasaBootstrap00},${piholeIpv6CasaBootstrap00}"
+    lbipam.cilium.io/sharing-key: casa-pihole
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+  ports:
+    - name: dns
+      port: 53
+      protocol: TCP
+      targetPort: dns
+    - name: dns-udp
+      port: 53
+      protocol: UDP
+      targetPort: dns-udp
+  type: LoadBalancer
+  loadBalancerClass: io.cilium/bgp-control-plane
+  # loadBalancerClass: io.cilium/l2-announcer
+  selector:
+    app: pihole
+    release: pihole-casa
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-k8s00
+  namespace: pihole
+  labels:
+    app: pihole-k8s00
+    network: k8s00
+  annotations:
+    lbipam.cilium.io/ips: "${piholeIpv4K8s00Bootstrap00},${piholeIpv6K8s00Bootstrap00}"
+    lbipam.cilium.io/sharing-key: k8s00-pihole
+spec:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+  ports:
+    - name: dns
+      port: 53
+      protocol: TCP
+      targetPort: dns
+    - name: dns-udp
+      port: 53
+      protocol: UDP
+      targetPort: dns-udp
+  type: LoadBalancer
+  loadBalancerClass: io.cilium/bgp-control-plane
+  # loadBalancerClass: io.cilium/l2-announcer
+  selector:
+    app: pihole
+    release: pihole-k8s00


### PR DESCRIPTION
This pull request introduces a comprehensive setup for deploying multiple Pi-hole instances in a Kubernetes cluster using FluxCD and Helm. The changes add a new `pihole` namespace, define Helm repository and release configurations for different Pi-hole deployments (targeting various network segments), provision required Kubernetes services with Cilium load balancer integration, and manage secrets securely with SOPS.

The most important changes are:

**Namespace and Helm Repository Setup:**
- Added the `pihole` namespace to the cluster and defined a `HelmRepository` resource pointing to the official Pi-hole Helm chart repository, enabling Helm-based deployments in the `pihole` namespace. [[1]](diffhunk://#diff-7b00405d9f1462982441d1568a76a62178ade58af5a8f60db0401e7c9c0bb658L6-R10) [[2]](diffhunk://#diff-c9bc4e062e5c6237c275a5ba30e2d023112c37e2d70f2fc345f71d8687c1a800R1-R9)

**Pi-hole Deployments (HelmReleases):**
- Introduced four separate `HelmRelease` resources (`pihole-mgmt`, `pihole-service`, `pihole-casa`, `pihole-k8s00`) to deploy Pi-hole instances with tailored configurations for different network segments or purposes, each with their own ingress, upstream DNS, and environment settings. [[1]](diffhunk://#diff-9821e9ef2e5616f24dc6868ebbd9ba12d7687363c0b6ea651403f6ed2aae8ff1R1-R72) [[2]](diffhunk://#diff-d7c77df594e39de27a8f60d68449560c1abc3af92e634925067af8eec8ea5ec1R1-R60) [[3]](diffhunk://#diff-974cbed593596b536bd34cf81220fe70e0ab55a50f02a09c2915042011819702R1-R59) [[4]](diffhunk://#diff-a0a6ba7757e0266eefeb9f984def783c1c292a47c60df7518f41330f2e422be1R1-R59)

**Service Definitions and Load Balancing:**
- Defined four corresponding `Service` resources (one for each HelmRelease) with dual-stack (IPv4/IPv6) support, Cilium BGP load balancer integration, and specific IP assignments for each network, ensuring external DNS accessibility and network segmentation.

**Secrets Management:**
- Added a SOPS-encrypted Kubernetes `Secret` containing the Pi-hole admin password, referenced by all HelmReleases for secure credential management.