### PR TITLE
fix: bootstrap00: pihole: dns upstream

### DIFF
--- a/kubernetes/apps/bootstrap00/pihole/pihole-casa.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-casa.yaml
@@ -20,6 +20,7 @@ spec:
       enabled: true
       existingSecret: pihole
       passwordKey: password
+    DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00};${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
     doh:
       enabled: false
     dualStack:
@@ -27,7 +28,6 @@ spec:
     extraEnvVars:
       FTLCONF_dns_listeningMode: 'all'
     ftl:
-      dns_upstreams: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00};${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
       dns_rateLimit_count: "100000"
       dns_rateLimit_interval: "15"
       ntp_ipv4_active: false

--- a/kubernetes/apps/bootstrap00/pihole/pihole-k8s00.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-k8s00.yaml
@@ -20,6 +20,7 @@ spec:
       enabled: true
       existingSecret: pihole
       passwordKey: password
+    DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00};${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
     doh:
       enabled: false
     dualStack:
@@ -27,7 +28,6 @@ spec:
     extraEnvVars:
       FTLCONF_dns_listeningMode: 'all'
     ftl:
-      dns_upstreams: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00};${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
       dns_rateLimit_count: "100000"
       dns_rateLimit_interval: "15"
       ntp_ipv4_active: false

--- a/kubernetes/apps/bootstrap00/pihole/pihole-mgmt.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-mgmt.yaml
@@ -30,6 +30,7 @@ spec:
         - address=/router/${routerIpMgmt}
         - address=/nas00/${nasIpmgmt}
       enableCustomDnsMasq: true
+    DNS1: "${piholeIpv4K8s00Bootstrap00};${piholeIpv4K8s00K8s00};${piholeIpv6K8s00Bootstrap00};${piholeIpv6K8s00K8s00}"
     doh:
       enabled: false
     dualStack:
@@ -37,7 +38,6 @@ spec:
     extraEnvVars:
       FTLCONF_dns_listeningMode: 'all'
     ftl:
-      dns_upstreams: "${piholeIpv4K8s00Bootstrap00};${piholeIpv4K8s00K8s00};${piholeIpv6K8s00Bootstrap00};${piholeIpv6K8s00K8s00}"
       dns_rateLimit_count: "100000"
       dns_rateLimit_interval: "15"
       ntp_ipv4_active: false


### PR DESCRIPTION
This pull request updates the DNS configuration for the Pi-hole deployments in the Kubernetes cluster. The main change is moving the list of DNS upstream servers from the `ftl.dns_upstreams` field to a new `DNS1` field in the configuration for all Pi-hole environments. This likely aligns with a change in how upstream DNS servers are specified or consumed by the deployment.

**DNS Upstream Configuration Updates:**

* Moved the upstream DNS server list from `ftl.dns_upstreams` to the new `DNS1` field in `pihole-casa.yaml`, `pihole-k8s00.yaml`, and `pihole-mgmt.yaml`, ensuring all relevant environments use the updated configuration method. [[1]](diffhunk://#diff-974cbed593596b536bd34cf81220fe70e0ab55a50f02a09c2915042011819702R23-L30) [[2]](diffhunk://#diff-a0a6ba7757e0266eefeb9f984def783c1c292a47c60df7518f41330f2e422be1R23-L30) [[3]](diffhunk://#diff-9821e9ef2e5616f24dc6868ebbd9ba12d7687363c0b6ea651403f6ed2aae8ff1R33-L40)