### PR TITLE
fix: bootstrap00: pihole: add casa

### DIFF
--- a/kubernetes/clusters/bootstrap00/cilium.values.sops.yaml
+++ b/kubernetes/clusters/bootstrap00/cilium.values.sops.yaml
@@ -14,6 +14,8 @@ stringData:
   ipv6_k8s00_bgp_cidr: ENC[AES256_GCM,data:RAuljfg6JUH138hntFDzgI8tgKck3jZafQ==,iv:bFOKq+1hY9tkc4XPHdec2Um1b0Y+o9We0zGhjivihH4=,tag:DORg94EDUTG2jSZFoU1lkg==,type:str]
   ipv4_monitoring_bgp_cidr: ENC[AES256_GCM,data:Gbb/fFr7aQxbRf6KIZdu,iv:FjknLJpFBGcXqBk/qTK7yXpu7/wvinKUhF5dpmaoWWc=,tag:WXl6MnQsBZ++7cTOhTgeGQ==,type:str]
   ipv6_monitoring_bgp_cidr: ENC[AES256_GCM,data:zcUG2L2yA1fj/tqvvlzlNHssjcyGzmwBfQ==,iv:+dBIOmlYVdyw9qoaQgBRC7uQh41DQNrlG+YSWx/IU6Y=,tag:7xIFL9+MWsBf5oeEWHVA9Q==,type:str]
+  ipv4_casa_bgp_cidr: ENC[AES256_GCM,data:/H3bOwaL48hQPCEd7NIb,iv:UOu+r1Ty8rvQHSpDJs5UfuMLQ9sOMMJE+r0BCTSMwOY=,tag:Pup+e5LHqoLcqQgxVhuOjA==,type:str]
+  ipv6_casa_bgp_cidr: ENC[AES256_GCM,data:Cv8srQjJXlQX3lFBqpYe+W7JGelqCW5onQ==,iv:WwMi3DL62VDJ410J+yQ2uJk4B6yBkgOTr1hSR5RLD7c=,tag:unsuPBV+1veU8xJugQXWUg==,type:str]
 sops:
   age:
     - enc: |
@@ -26,6 +28,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-07T15:38:13Z"
-  mac: ENC[AES256_GCM,data:ivVkF7K5krsy51EpRvRGYgMHRkiTkAUX1qE5tinZOwDdAlda3qa+Wh16StcdrLXUniOg8+grGBLO1tIql2d5ycNC6TIUzLV7az4QJliONjgC2wN/R1vNDFwGDQv4Lvx2JrFb5ElG8D/lGMoVx1FOWOt6GLylGC/UhmB8nA8rbVQ=,iv:j0orfYLF/T9FQ4yXrSrm1lTsMZLuFOJcsyklyHcfRoY=,tag:CetutC4dkCIQJJkGSK37IQ==,type:str]
+  lastmodified: "2026-06-24T23:14:13Z"
+  mac: ENC[AES256_GCM,data:OnTaqj2kdCswaQ+I3Y24wEjXtTQSVaJGu8XRWnGbmVvzlzwwGd2pCcLkr9B0fcrDzFCVzx+ZLazDGtL+m3U7PkyURQe8Nbwbk7Ooff9bwGWFbrW9HUADhhDDC384jDDKZ1/KCj9wV9HpjCtXdOiXW9c+doQHNZVY4xj1jbAV2z4=,iv:JMph75BtXAbkdWhrhiaTCYxPhZuLOBd1QULvgxmRxvU=,tag:OhBfKcEoQm/3zWlihF1nBg==,type:str]
   version: 3.13.1

--- a/kubernetes/infrastructure/bootstrap00/cilium/load-balancer-ip-pool.yaml
+++ b/kubernetes/infrastructure/bootstrap00/cilium/load-balancer-ip-pool.yaml
@@ -54,3 +54,17 @@ spec:
   serviceSelector:
     matchLabels:
       network: monitoring
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: service-pool-casa
+spec:
+  allowFirstLastIPs: "No"
+  blocks:
+    - cidr: ${ipv4_casa_bgp_cidr}
+    - cidr: ${ipv6_casa_bgp_cidr}
+  disabled: false
+  serviceSelector:
+    matchLabels:
+      network: casa


### PR DESCRIPTION
This pull request adds support for a new "casa" network to the Cilium load balancer IP pool configuration in the bootstrap00 cluster. The main changes introduce new encrypted BGP CIDR secrets for the "casa" network and update the load balancer IP pool YAML to include a new pool for this network.

**Cilium Casa Network Support:**

* Added new encrypted secrets for `ipv4_casa_bgp_cidr` and `ipv6_casa_bgp_cidr` in `cilium.values.sops.yaml` to securely store the BGP CIDRs for the "casa" network.
* Updated the SOPS metadata (`lastmodified` and `mac`) in `cilium.values.sops.yaml` to reflect the new secrets.

**Load Balancer IP Pool Configuration:**

* Added a new `CiliumLoadBalancerIPPool` resource named `service-pool-casa` in `load-balancer-ip-pool.yaml`, which uses the new casa BGP CIDRs and selects services labeled with `network: casa`.