### PR TITLE
fix: bootstrap00 and k8s00: pihole: dns upstream

### DIFF
--- a/kubernetes/apps/bootstrap00/pihole/pihole-casa.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-casa.yaml
@@ -20,7 +20,7 @@ spec:
       enabled: true
       existingSecret: pihole
       passwordKey: password
-    DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00}
+    DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00}"
     DNS2: "${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
     doh:
       enabled: false

--- a/kubernetes/apps/bootstrap00/pihole/pihole-casa.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-casa.yaml
@@ -20,7 +20,8 @@ spec:
       enabled: true
       existingSecret: pihole
       passwordKey: password
-    DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00};${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
+    DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00}
+    DNS2: "${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
     doh:
       enabled: false
     dualStack:

--- a/kubernetes/apps/bootstrap00/pihole/pihole-k8s00.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-k8s00.yaml
@@ -20,7 +20,8 @@ spec:
       enabled: true
       existingSecret: pihole
       passwordKey: password
-    DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00};${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
+    DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00}"
+    DNS2: "${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
     doh:
       enabled: false
     dualStack:

--- a/kubernetes/apps/bootstrap00/pihole/pihole-mgmt.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-mgmt.yaml
@@ -30,7 +30,8 @@ spec:
         - address=/router/${routerIpMgmt}
         - address=/nas00/${nasIpmgmt}
       enableCustomDnsMasq: true
-    DNS1: "${piholeIpv4K8s00Bootstrap00};${piholeIpv4K8s00K8s00};${piholeIpv6K8s00Bootstrap00};${piholeIpv6K8s00K8s00}"
+    DNS1: "${piholeIpv4K8s00Bootstrap00};${piholeIpv4K8s00K8s00}"
+    DNS2: "${piholeIpv6K8s00Bootstrap00};${piholeIpv6K8s00K8s00}"
     doh:
       enabled: false
     dualStack:

--- a/kubernetes/apps/k8s00/pihole/pihole-casa.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-casa.yaml
@@ -20,6 +20,8 @@ spec:
       enabled: true
       existingSecret: pihole
       passwordKey: password
+    DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00}"
+    DNS2: "${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
     doh:
       enabled: false
     dualStack:
@@ -27,7 +29,6 @@ spec:
     extraEnvVars:
       FTLCONF_dns_listeningMode: 'all'
     ftl:
-      dns_upstreams: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00};${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
       dns_rateLimit_count: "100000"
       dns_rateLimit_interval: "15"
       ntp_ipv4_active: false

--- a/kubernetes/apps/k8s00/pihole/pihole-k8s00.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-k8s00.yaml
@@ -20,6 +20,8 @@ spec:
       enabled: true
       existingSecret: pihole
       passwordKey: password
+    DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00}"
+    DNS2: "${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
     doh:
       enabled: false
     dualStack:
@@ -27,7 +29,6 @@ spec:
     extraEnvVars:
       FTLCONF_dns_listeningMode: 'all'
     ftl:
-      dns_upstreams: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00};${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
       dns_rateLimit_count: "100000"
       dns_rateLimit_interval: "15"
       ntp_ipv4_active: false

--- a/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
@@ -20,6 +20,8 @@ spec:
       enabled: true
       existingSecret: pihole
       passwordKey: password
+    DNS1: "${piholeIpv4K8s00Bootstrap00};${piholeIpv4K8s00K8s00}"
+    DNS2: "${piholeIpv6K8s00Bootstrap00};${piholeIpv6K8s00K8s00}"
     dnsmasq:
       customCnameEntries:
         - cname=router.${mgmtDomainOld},router
@@ -37,7 +39,6 @@ spec:
     extraEnvVars:
       FTLCONF_dns_listeningMode: 'all'
     ftl:
-      dns_upstreams: "${piholeIpv4K8s00Bootstrap00};${piholeIpv4K8s00K8s00};${piholeIpv6K8s00Bootstrap00};${piholeIpv6K8s00K8s00}"
       dns_rateLimit_count: "100000"
       dns_rateLimit_interval: "15"
       ntp_ipv4_active: false


### PR DESCRIPTION
This pull request updates the DNS configuration for multiple Pi-hole deployments in Kubernetes to separate IPv4 and IPv6 upstream servers into distinct environment variables (`DNS1` and `DNS2`). This change improves clarity and maintainability of DNS settings across different environments by explicitly distinguishing between IPv4 and IPv6 upstreams.

**DNS Configuration Refactoring:**

* For all Pi-hole deployments (`pihole-casa`, `pihole-k8s00`, and `pihole-mgmt` in both `bootstrap00` and `k8s00` clusters), the combined `DNS1` variable containing both IPv4 and IPv6 addresses has been split into `DNS1` (IPv4 addresses) and `DNS2` (IPv6 addresses). [[1]](diffhunk://#diff-974cbed593596b536bd34cf81220fe70e0ab55a50f02a09c2915042011819702L23-R24) [[2]](diffhunk://#diff-a0a6ba7757e0266eefeb9f984def783c1c292a47c60df7518f41330f2e422be1L23-R24) [[3]](diffhunk://#diff-9821e9ef2e5616f24dc6868ebbd9ba12d7687363c0b6ea651403f6ed2aae8ff1L33-R34) [[4]](diffhunk://#diff-e19db1c84bcd009d05ec1b40c4774a9b32df3c010914b8b62d2e038049fabc4cR23-L30) [[5]](diffhunk://#diff-7e04604a89db2c49d4a52cb83c124ac4eacd1caf5943714066a1ce48ae6c00b9R23-L30) [[6]](diffhunk://#diff-195c8950f420a5dd1ff5f320f5590ae12537ee26c4bce5153a05969077ddca61R23-R24)

* The `ftl.dns_upstreams` configuration, which previously listed both IPv4 and IPv6 addresses in a single string, has been removed from the environment-specific Pi-hole YAML files, likely to rely on the new `DNS1`/`DNS2` variables. [[1]](diffhunk://#diff-e19db1c84bcd009d05ec1b40c4774a9b32df3c010914b8b62d2e038049fabc4cR23-L30) [[2]](diffhunk://#diff-7e04604a89db2c49d4a52cb83c124ac4eacd1caf5943714066a1ce48ae6c00b9R23-L30) [[3]](diffhunk://#diff-195c8950f420a5dd1ff5f320f5590ae12537ee26c4bce5153a05969077ddca61L40)