### PR TITLE
fix: k8s00: pihole: dns upstream

### DIFF
--- a/kubernetes/apps/k8s00/pihole/pihole-casa.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-casa.yaml
@@ -20,8 +20,10 @@ spec:
       enabled: true
       existingSecret: pihole
       passwordKey: password
-    DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00}"
-    DNS2: "${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
+    # DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00}"
+    # DNS2: "${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
+    DNS1: "${piholeIpv4ServiceBootstrap00}"
+    DNS2: "${piholeIpv4ServiceK8s00}"
     doh:
       enabled: false
     dualStack:

--- a/kubernetes/apps/k8s00/pihole/pihole-k8s00.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-k8s00.yaml
@@ -20,8 +20,10 @@ spec:
       enabled: true
       existingSecret: pihole
       passwordKey: password
-    DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00}"
-    DNS2: "${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
+    # DNS1: "${piholeIpv4ServiceBootstrap00};${piholeIpv4ServiceK8s00}"
+    # DNS2: "${piholeIpv6ServiceBootstrap00};${piholeIpv6ServiceK8s00}"
+    DNS1: "${piholeIpv4ServiceBootstrap00}"
+    DNS2: "${piholeIpv4ServiceK8s00}"
     doh:
       enabled: false
     dualStack:

--- a/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
@@ -20,8 +20,10 @@ spec:
       enabled: true
       existingSecret: pihole
       passwordKey: password
-    DNS1: "${piholeIpv4K8s00Bootstrap00};${piholeIpv4K8s00K8s00}"
-    DNS2: "${piholeIpv6K8s00Bootstrap00};${piholeIpv6K8s00K8s00}"
+    # DNS1: "${piholeIpv4K8s00Bootstrap00};${piholeIpv4K8s00K8s00}"
+    # DNS2: "${piholeIpv6K8s00Bootstrap00};${piholeIpv6K8s00K8s00}"
+    DNS1: "${piholeIpv4K8s00Bootstrap00}"
+    DNS2: "${piholeIpv4K8s00K8s00}"
     dnsmasq:
       customCnameEntries:
         - cname=router.${mgmtDomainOld},router


### PR DESCRIPTION
This pull request updates the DNS configuration for the Pihole deployments in the Kubernetes cluster. The main change is to simplify the `DNS1` and `DNS2` environment variables by specifying only a single IPv4 address for each, instead of a semicolon-separated list of IPv4 and IPv6 addresses. The previous configuration is commented out for reference.

DNS configuration changes:

* Updated `DNS1` and `DNS2` in `pihole-casa.yaml` to use only the IPv4 service addresses, with the previous dual-stack (IPv4 and IPv6) configuration commented out.
* Updated `DNS1` and `DNS2` in `pihole-k8s00.yaml` to use only the IPv4 service addresses, with the previous dual-stack configuration commented out.
* Updated `DNS1` and `DNS2` in `pihole-mgmt.yaml` to use only the IPv4 service addresses, with the previous dual-stack configuration commented out.