### PR TITLE
feat: k8s00: ingress: add mgmt controller

### DIFF
--- a/kubernetes/apps/k8s00/pihole/pihole-casa.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-casa.yaml
@@ -41,7 +41,7 @@ spec:
       enabled: true
       annotations:
         cert-manager.io/cluster-issuer: homelab-internal
-      ingressClassName: nginx
+      ingressClassName: nginx-mgmt
       hosts:
         - piholecasa.k8s00.${mgmtDomainOld}
       path: /

--- a/kubernetes/apps/k8s00/pihole/pihole-k8s00.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-k8s00.yaml
@@ -41,7 +41,7 @@ spec:
       enabled: true
       annotations:
         cert-manager.io/cluster-issuer: homelab-internal
-      ingressClassName: nginx
+      ingressClassName: nginx-mgmt
       hosts:
         - piholek8s00.k8s00.${mgmtDomainOld}
       path: /

--- a/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
@@ -54,7 +54,7 @@ spec:
       enabled: true
       annotations:
         cert-manager.io/cluster-issuer: homelab-internal
-      ingressClassName: nginx
+      ingressClassName: nginx-mgmt
       hosts:
         - piholemgmt.k8s00.${mgmtDomainOld}
       path: /

--- a/kubernetes/apps/k8s00/pihole/pihole-service.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-service.yaml
@@ -39,7 +39,7 @@ spec:
       enabled: true
       annotations:
         cert-manager.io/cluster-issuer: homelab-internal
-      ingressClassName: nginx
+      ingressClassName: nginx-mgmt
       hosts:
         - piholeservice.k8s00.${mgmtDomainOld}
       path: /

--- a/kubernetes/clusters/k8s00/global.variables.sops.yaml
+++ b/kubernetes/clusters/k8s00/global.variables.sops.yaml
@@ -39,6 +39,7 @@ stringData:
   piholeIpv6ServiceK8s00: ENC[AES256_GCM,data:TfmeZ2utb0da1BOlKY4uUZS3RBLO/w==,iv:1+mhly/RHrO/MLWd1IVgG4BJ41Mbn0y1rnlBjzrRMRA=,tag:vB93RX9CDbODkDNiT89Vtw==,type:str]
   piholeIpv4CasaK8s00: ENC[AES256_GCM,data:NQ5MW7UOgPlf/74D,iv:Lu2ElPJQouGSlmjVgJriFV6lefoUPL9zQrM5C12pMew=,tag:f4ou8w2S03Hys+IcbD8OhA==,type:str]
   piholeIpv6CasaK8s00: ENC[AES256_GCM,data:EiJke7cCg8DClPnyu31kNNhVOA/07w==,iv:w7XJZZ9XRDV1aag8348ojVXLM7iA+pHfD9JFi6k6FPw=,tag:qz3VcWEVE38ZRIAYY1Q5Lg==,type:str]
+  ingressMgmtIpv4: ENC[AES256_GCM,data:hPZxVR77ZxbUfz8=,iv:buFm/+GT7rqMK6Q7UB4pvqyCOWr05/luMRNeYwkaRBc=,tag:Ai1fustis351WMSeeugrMA==,type:str]
 sops:
   age:
     - enc: |
@@ -51,6 +52,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-24T22:06:50Z"
-  mac: ENC[AES256_GCM,data:SrIOIGNKZ3h67d5nHBUeDAAaZct1yPmRwgxeZSfiP8OvMh6kavuqYRm5LVu2kMRnPP9lucenWaLwHdgsDllbFHffNGf6bW21Zr11GqNGwd0WmUY+aTNfDFPSOG2+mB0/i7N8sIrWsQZ9WfUHbyWeYQlevWyDUtsRuKjUT0IBlUA=,iv:2Gf3/VhArkIANzx57tKwgME+4acSZv65V1fq3shvNUg=,tag:uKEf7Zk5INxODKl+h1VpYQ==,type:str]
+  lastmodified: "2026-06-25T10:13:55Z"
+  mac: ENC[AES256_GCM,data:yjMMG2KV7M7pw/klHtbVm+bSFdiSy3RanYTEL+zB3MFZRsXTzAhmyGW39egJG1r3kKyCk0Gdfgj5jHfxxZjtlxDbqdc+OMtoBC9FgQuz6I0AIrQeZFyZewvTMLEk8Zky4LrccP+lkwK6RiO3XT48f+0Yh16LNl5gjJ40rVQ0/ko=,iv:brAVDnLFN8mCrSZwiVSSbkS92IPkiNWmL+x48yCY+bY=,tag:HDQyYmYEXmNF+5AszRVpKw==,type:str]
   version: 3.13.1

--- a/kubernetes/infrastructure/k8s00/ingress-nginx.yaml
+++ b/kubernetes/infrastructure/k8s00/ingress-nginx.yaml
@@ -61,6 +61,11 @@ spec:
   values:
     controller:
       ingressClass: nginx-mgmt
+      ingressClassResource:
+        name: nginx-mgmt
+        enabled: true
+        default: false
+        controllerValue: "k8s.io/ingress-nginx-mgmt"
       metrics:
         enabled: false
       service:

--- a/kubernetes/infrastructure/k8s00/ingress-nginx.yaml
+++ b/kubernetes/infrastructure/k8s00/ingress-nginx.yaml
@@ -39,3 +39,38 @@ spec:
           enabled: true
         prometheusRule:
           enabled: true
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ingress-nginx-mgmt
+  namespace: ingress-nginx
+spec:
+  interval: 30m
+  install:
+    createNamespace: true
+  chart:
+    spec:
+      chart: ingress-nginx
+      version: ">= 4.15.1 < 4.16.0"
+      sourceRef:
+        kind: HelmRepository
+        name: ingress-nginx
+        namespace: flux-system
+      interval: 1m
+  values:
+    controller:
+      ingressClass: nginx-mgmt
+      metrics:
+        enabled: false
+      service:
+        annotations:
+          lbipam.cilium.io/ips: "${ingressMgmtIpv4}"
+        #   lbipam.cilium.io/ips: "${ingressMgmtIpv4},${ingressMgmtIpv6}"
+        # ipFamilies:
+        #   - IPv4
+        #   - IPv6
+        # ipFamilyPolicy: PreferDualStack
+        labels:
+          network: mgmt
+        loadBalancerClass: io.cilium/bgp-control-plane


### PR DESCRIPTION
This pull request introduces a new dedicated management ingress controller (`nginx-mgmt`) to the Kubernetes cluster, updates Pi-hole ingress resources to use this new controller, and adds supporting configuration and secrets. This change improves network separation and management by directing management-related traffic through a distinct ingress path.

**Ingress controller improvements:**

* Added a new `HelmRelease` for the `ingress-nginx-mgmt` ingress controller in `ingress-nginx` namespace, with custom settings including a dedicated ingress class (`nginx-mgmt`), Cilium BGP load balancer, and management IP annotation.

**Ingress resource updates:**

* Updated all Pi-hole ingress resources (`pihole-casa.yaml`, `pihole-k8s00.yaml`, `pihole-mgmt.yaml`, `pihole-service.yaml`) to use the new `nginx-mgmt` ingress class instead of the default `nginx`. [[1]](diffhunk://#diff-e19db1c84bcd009d05ec1b40c4774a9b32df3c010914b8b62d2e038049fabc4cL44-R44) [[2]](diffhunk://#diff-7e04604a89db2c49d4a52cb83c124ac4eacd1caf5943714066a1ce48ae6c00b9L44-R44) [[3]](diffhunk://#diff-195c8950f420a5dd1ff5f320f5590ae12537ee26c4bce5153a05969077ddca61L57-R57) [[4]](diffhunk://#diff-c22870880761b0997972dfe65d0c6eb202a778e2745cc73a9bdb33e9feecf7b9L42-R42)

**Configuration and secrets:**

* Added a new encrypted variable `ingressMgmtIpv4` to `global.variables.sops.yaml` to provide the management ingress IP for the new controller.
* Updated SOPS metadata to reflect the addition of the new secret.