### PR TITLE
feat: k8s00: ingress: wrong ip attribution

### DIFF
--- a/kubernetes/clusters/k8s00/global.variables.sops.yaml
+++ b/kubernetes/clusters/k8s00/global.variables.sops.yaml
@@ -39,7 +39,7 @@ stringData:
   piholeIpv6ServiceK8s00: ENC[AES256_GCM,data:TfmeZ2utb0da1BOlKY4uUZS3RBLO/w==,iv:1+mhly/RHrO/MLWd1IVgG4BJ41Mbn0y1rnlBjzrRMRA=,tag:vB93RX9CDbODkDNiT89Vtw==,type:str]
   piholeIpv4CasaK8s00: ENC[AES256_GCM,data:NQ5MW7UOgPlf/74D,iv:Lu2ElPJQouGSlmjVgJriFV6lefoUPL9zQrM5C12pMew=,tag:f4ou8w2S03Hys+IcbD8OhA==,type:str]
   piholeIpv6CasaK8s00: ENC[AES256_GCM,data:EiJke7cCg8DClPnyu31kNNhVOA/07w==,iv:w7XJZZ9XRDV1aag8348ojVXLM7iA+pHfD9JFi6k6FPw=,tag:qz3VcWEVE38ZRIAYY1Q5Lg==,type:str]
-  ingressMgmtIpv4: ENC[AES256_GCM,data:hPZxVR77ZxbUfz8=,iv:buFm/+GT7rqMK6Q7UB4pvqyCOWr05/luMRNeYwkaRBc=,tag:Ai1fustis351WMSeeugrMA==,type:str]
+  ingressMgmtIpv4: ENC[AES256_GCM,data:oUDfx+bF+eb86Xw=,iv:R8wdIJe8J5x0sIq3m5ulSRTAceEsehcm+uKDkYI9lXs=,tag:Ul5NOzDqPiIiMypWjcdMJg==,type:str]
 sops:
   age:
     - enc: |
@@ -52,6 +52,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-25T10:13:55Z"
-  mac: ENC[AES256_GCM,data:yjMMG2KV7M7pw/klHtbVm+bSFdiSy3RanYTEL+zB3MFZRsXTzAhmyGW39egJG1r3kKyCk0Gdfgj5jHfxxZjtlxDbqdc+OMtoBC9FgQuz6I0AIrQeZFyZewvTMLEk8Zky4LrccP+lkwK6RiO3XT48f+0Yh16LNl5gjJ40rVQ0/ko=,iv:brAVDnLFN8mCrSZwiVSSbkS92IPkiNWmL+x48yCY+bY=,tag:HDQyYmYEXmNF+5AszRVpKw==,type:str]
+  lastmodified: "2026-06-25T10:55:03Z"
+  mac: ENC[AES256_GCM,data:jUAp9mWH7dkxDnfdQKdJ68lErke4HoV/CYAp3cMRb7H43ZRqdcqjd5oOK2MUZ66x3+kS++gr0OTL90U+GO2KlcL+8EJ2rLWw2TrdVwCWqpgOTZX9AAEGiEg6+fcKJA/cSr+XZFoPeRuVEEaoammcNlLSFGzqXr2wsbGS7fkei7Y=,iv:fr1jjQmR66RoYuCOe+LLLpVjIRIRKJQiKK4to23faq4=,tag:bpOm3F+Gcb2n/A1wKRaqIQ==,type:str]
   version: 3.13.1


### PR DESCRIPTION
This pull request updates the encrypted value for the `ingressMgmtIpv4` variable in the `kubernetes/clusters/k8s00/global.variables.sops.yaml` file. The SOPS metadata has also been updated to reflect this change.

Secrets update:

* Updated the encrypted value for `ingressMgmtIpv4` in `stringData` to a new encrypted string.

SOPS metadata update:

* Updated the `lastmodified` timestamp and the `mac` (message authentication code) in the `sops` section to reflect the new encryption.