### PR TITLE
feat: k8s00: cert-manager: add solver for mgmt

### DIFF
--- a/kubernetes/infrastructure/k8s00/issuers.yaml
+++ b/kubernetes/infrastructure/k8s00/issuers.yaml
@@ -20,4 +20,10 @@ spec:
     solvers:
     - http01:
         ingress:
+          ingressClassName: nginx-mgmt
+      selector:
+        matchLabels:
+          network: mgmt
+    - http01:
+        ingress:
           ingressClassName: nginx

--- a/kubernetes/infrastructure/k8s00/issuers.yaml
+++ b/kubernetes/infrastructure/k8s00/issuers.yaml
@@ -18,12 +18,12 @@ spec:
       name: homelab-internal-account-private-key
     # Add a single challenge solver, HTTP01 using nginx
     solvers:
-    - http01:
-        ingress:
-          ingressClassName: nginx-mgmt
-      selector:
-        matchLabels:
-          network: mgmt
-    - http01:
-        ingress:
-          ingressClassName: nginx
+      - http01:
+          ingress:
+            ingressClassName: nginx-mgmt
+        selector:
+          matchLabels:
+            network: mgmt
+      - http01:
+          ingress:
+            ingressClassName: nginx


### PR DESCRIPTION
This pull request updates the certificate issuer configuration in `issuers.yaml` to support certificate challenges on the management network. The main change is the addition of a new HTTP01 solver specifically for the `nginx-mgmt` ingress class, allowing certificate management for resources labeled with the `mgmt` network.

Certificate challenge solver enhancements:

* Added a new HTTP01 solver using the `nginx-mgmt` ingress class, with a selector to match resources labeled with `network: mgmt`, enabling certificate issuance for the management network.