### PR TITLE
fix: k8s00: cert-manager: clusterIssuer: switch selector to dnsZones

### DIFF
--- a/kubernetes/infrastructure/k8s00/issuers.yaml
+++ b/kubernetes/infrastructure/k8s00/issuers.yaml
@@ -23,8 +23,8 @@ spec:
             ingressClassName: nginx-mgmt
         selector:
           dnsZones:
-            - "$[mgmtDomainOld]"
-            - "$[mgmtDomain]"
+            - "${mgmtDomainOld}"
+            - "${mgmtDomain}"
       - http01:
           ingress:
             ingressClassName: nginx

--- a/kubernetes/infrastructure/k8s00/issuers.yaml
+++ b/kubernetes/infrastructure/k8s00/issuers.yaml
@@ -22,8 +22,9 @@ spec:
           ingress:
             ingressClassName: nginx-mgmt
         selector:
-          matchLabels:
-            network: mgmt
+          dnsZones:
+            - "$[mgmtDomainOld]"
+            - "$[mgmtDomain]"
       - http01:
           ingress:
             ingressClassName: nginx


### PR DESCRIPTION
This pull request updates the `issuers.yaml` configuration to change how issuers are selected for management domains. Instead of using a label selector, it now specifies a list of DNS zones for issuer selection.

Issuer selection changes:

* Replaced the `matchLabels` selector (which matched on `network: mgmt`) with a `dnsZones` list that includes both `$[mgmtDomainOld]` and `$[mgmtDomain]` for more flexible issuer selection in `kubernetes/infrastructure/k8s00/issuers.yaml`.