### PR TITLE
feat: bootstrap00 and k8s00: pihole: mgmt: add addresses

### DIFF
--- a/kubernetes/apps/bootstrap00/pihole/pihole-mgmt.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-mgmt.yaml
@@ -29,6 +29,10 @@ spec:
       customDnsEntries:
         - address=/router/${routerIpMgmt}
         - address=/nas00/${nasIpmgmt}
+        - address=/piholemgmt.bootstrap00.${mgmtDomainOld}/${piholeIpv4MgmtBootstrap00}
+        - address=/piholemgmt.bootstrap00.${mgmtDomainOld}/${piholeIpv6MgmtBootstrap00}
+        - address=/piholemgmt.k8s00.${mgmtDomainOld}/${piholeIpv4MgmtK8s00}
+        - address=/piholemgmt.k8s00.${mgmtDomainOld}/${piholeIpv6MgmtK8s00}
       enableCustomDnsMasq: true
     DNS1: "${piholeIpv4K8s00Bootstrap00};${piholeIpv4K8s00K8s00}"
     DNS2: "${piholeIpv6K8s00Bootstrap00};${piholeIpv6K8s00K8s00}"

--- a/kubernetes/apps/bootstrap00/pihole/pihole-mgmt.yaml
+++ b/kubernetes/apps/bootstrap00/pihole/pihole-mgmt.yaml
@@ -31,8 +31,12 @@ spec:
         - address=/nas00/${nasIpmgmt}
         - address=/piholemgmt.bootstrap00.${mgmtDomainOld}/${piholeIpv4MgmtBootstrap00}
         - address=/piholemgmt.bootstrap00.${mgmtDomainOld}/${piholeIpv6MgmtBootstrap00}
+        - address=/piholemgmt.bootstrap00.${mgmtDomain}/${piholeIpv4MgmtBootstrap00}
+        - address=/piholemgmt.bootstrap00.${mgmtDomain}/${piholeIpv6MgmtBootstrap00}
         - address=/piholemgmt.k8s00.${mgmtDomainOld}/${piholeIpv4MgmtK8s00}
         - address=/piholemgmt.k8s00.${mgmtDomainOld}/${piholeIpv6MgmtK8s00}
+        - address=/piholemgmt.k8s00.${mgmtDomain}/${piholeIpv4MgmtK8s00}
+        - address=/piholemgmt.k8s00.${mgmtDomain}/${piholeIpv6MgmtK8s00}
       enableCustomDnsMasq: true
     DNS1: "${piholeIpv4K8s00Bootstrap00};${piholeIpv4K8s00K8s00}"
     DNS2: "${piholeIpv6K8s00Bootstrap00};${piholeIpv6K8s00K8s00}"

--- a/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
@@ -33,6 +33,10 @@ spec:
       customDnsEntries:
         - address=/router/${routerIpMgmt}
         - address=/nas00/${nasIpmgmt}
+        - address=/piholemgmt.bootstrap00.${mgmtDomainOld}/${piholeIpv4MgmtBootstrap00}
+        - address=/piholemgmt.bootstrap00.${mgmtDomainOld}/${piholeIpv6MgmtBootstrap00}
+        - address=/piholemgmt.k8s00.${mgmtDomainOld}/${piholeIpv4MgmtK8s00}
+        - address=/piholemgmt.k8s00.${mgmtDomainOld}/${piholeIpv6MgmtK8s00}
       enableCustomDnsMasq: true
     doh:
       enabled: false

--- a/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
+++ b/kubernetes/apps/k8s00/pihole/pihole-mgmt.yaml
@@ -35,8 +35,12 @@ spec:
         - address=/nas00/${nasIpmgmt}
         - address=/piholemgmt.bootstrap00.${mgmtDomainOld}/${piholeIpv4MgmtBootstrap00}
         - address=/piholemgmt.bootstrap00.${mgmtDomainOld}/${piholeIpv6MgmtBootstrap00}
+        - address=/piholemgmt.bootstrap00.${mgmtDomain}/${piholeIpv4MgmtBootstrap00}
+        - address=/piholemgmt.bootstrap00.${mgmtDomain}/${piholeIpv6MgmtBootstrap00}
         - address=/piholemgmt.k8s00.${mgmtDomainOld}/${piholeIpv4MgmtK8s00}
         - address=/piholemgmt.k8s00.${mgmtDomainOld}/${piholeIpv6MgmtK8s00}
+        - address=/piholemgmt.k8s00.${mgmtDomain}/${piholeIpv4MgmtK8s00}
+        - address=/piholemgmt.k8s00.${mgmtDomain}/${piholeIpv6MgmtK8s00}
       enableCustomDnsMasq: true
     doh:
       enabled: false

--- a/kubernetes/clusters/bootstrap00/global.values.sops.yaml
+++ b/kubernetes/clusters/bootstrap00/global.values.sops.yaml
@@ -34,6 +34,8 @@ stringData:
   piholeUrlMgmtK8s00: ENC[AES256_GCM,data:vBTyBpVbG1eMu20Zr9/Yi9Irs+1tyQPQIJZ9zZUC9DSzCeX1tT/SbT68pA==,iv:Ut1seW85ri1ecvopE2GNAZjswcS7NoqESEBl/JnkH8Y=,tag:rmFePYUD9pV/3E0XddyMIA==,type:str]
   piholeIpv4MgmtBootstrap00: ENC[AES256_GCM,data:9q6rYLgcAvwTG3s=,iv:v27MCPy4bsORTnjS/UHARKYghdvcRpkHVCGUvjR4Onc=,tag:J3O2gcsqX6u5Y4JDeX1h1g==,type:str]
   piholeIpv6MgmtBootstrap00: ENC[AES256_GCM,data:8ijR1ziX9a3k4xdS91lKQ4eI/tJ2Mg==,iv:Ry8tS3fx2jNkqr1UxqJcdsL7ykJes0JReuTkZXr8PH8=,tag:M5xgd3IwGjXLZ+q1OONg7g==,type:str]
+  piholeIpv4MgmtK8s00: ENC[AES256_GCM,data:VQkkLcfVjYPd/aE=,iv:63ZtzYVM+Y7tZJF3r3b7eOTcc9NE17oQnvPUvik4e5E=,tag:Ktg7+QzpRm+aQwh42s/+Ng==,type:str]
+  piholeIpv6MgmtK8s00: ENC[AES256_GCM,data:emhzhbYm0tsAPsdQBClpmCfJUIGgpA==,iv:ll8kEO8U523AQLSDC+WYhuQ8j+WnHDGyDVilAIfgDk4=,tag:HdBizf2HHdIxSSW/b6L5DA==,type:str]
   piholeIpv4K8s00Bootstrap00: ENC[AES256_GCM,data:vPtF6MzB8lOlAsP5,iv:vswHT3UMqpXa45/y3KlBFPDCV66b2zy8uyDSHWYx2f0=,tag:5nTm12ilSN2K3R/s2ZeeNg==,type:str]
   piholeIpv6K8s00Bootstrap00: ENC[AES256_GCM,data:9xNM48U232Pziyn5G0UZUR+hsz4Gxg==,iv:eAmyJihNp+LOeIeW607irwxyGuD+hKwGsqqreabzT8U=,tag:YmUZg+lLbNK9omvyfIhaTw==,type:str]
   piholeIpv4K8s00K8s00: ENC[AES256_GCM,data:tgU6xwN6sivHjY7f,iv:BnhTStdzcfKnxkOSZ1Ex6eJv48bbA9ElXkDl3RnguJ4=,tag:RunJ83XUwnsZabBnAhi2pQ==,type:str]
@@ -56,6 +58,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-24T23:59:59Z"
-  mac: ENC[AES256_GCM,data:hfEHoaphHT1zRS4x9zf7Kci/+aWNPGu1FIhXC5btL9hlARK9xiiUKNGuPfdvng4/9e/YoBiAkPK3oMLYn9NpSSyWGBl1/R7JiCDNNjBFj8P6JPNH+WkNoJ7Q3NpZq5N47Xu2gdaRhnN04nBGrIBzkTCcZjUsrVrVGYKJl/buaeY=,iv:Yh4jHAdvRUf4u05xXDLIH+qjU2Z7fD+PHlbtLZbWLes=,tag:8xbDhHbujx0SgsUMaysbhg==,type:str]
+  lastmodified: "2026-06-29T19:47:36Z"
+  mac: ENC[AES256_GCM,data:lSuvv13pKvtVTd7yNz0Pcffb7F2ElFqYOji2XDMMRy5WsWOhr5jS9jfC1eXPdoaIPY+iQL7VwQLzYAxHlnkzdqIYlTYQE0AsOvr+smJqW5u8m3IETIhbPdpasS8HjoQFzCcexXeZzylwzV1moTfF3by9K0DEmA/DoVEZbD6YQ2o=,iv:KO6TzGwvpB2ZeGmVlb11SWdfeU+19HUA1UOMV5X/knk=,tag:j6oCF7R0EvgX9+g6YIEjOQ==,type:str]
   version: 3.13.1

--- a/kubernetes/clusters/k8s00/global.variables.sops.yaml
+++ b/kubernetes/clusters/k8s00/global.variables.sops.yaml
@@ -27,6 +27,8 @@ stringData:
   piholeUrlMgmtK8s00Internal: ENC[AES256_GCM,data:6VC2rihMJhFabrc7NtheCQumnCBoJK7+rmQ8dwA=,iv:Xp4O8fGN7Qe6FugBtBbpwURFSEmYOUQraXJceEAM2fM=,tag:CjwuIvSpeMmVk3lX8vMdJA==,type:str]
   piholeUrlK8s00Bootstrap00: ENC[AES256_GCM,data:NmyGE5grJY8ExRYNcqt59+zAEnjc/98G0cqHX5pY41VMop6rwtErXuAKTnz+L8DQjN0=,iv:aw/61XbCmn2oY8AGbkB7vkM1odMw/NnnqgZXrycBdAo=,tag:Lrwws474/Wqj5g+IwVQ9gw==,type:str]
   piholeUrlK8s00K8s00Internal: ENC[AES256_GCM,data:FTCI+8hsk+sgxv3ymXeprp2KJbiDsKmZ4b9cqXnH,iv:JDVy9CL2ZsUlfX34+gbBTC/D+vVNWALnExwdoSqjJIk=,tag:2VyE+OSvNAY9zUD7iLjDpw==,type:str]
+  piholeIpv4MgmtBootstrap00: ENC[AES256_GCM,data:nSi3csNZS+0lzco=,iv:IVrnT1kR6E6F3duuwj9hUCKz/1uGijZCAUE6Idyuiys=,tag:OM8c2cxn/vxouqOkDGNHBw==,type:str]
+  piholeIpv6MgmtBootstrap00: ENC[AES256_GCM,data:TtFk9EQbrVcKE5xnoxuh/AVD5yQNWA==,iv:MJFNIXExX74lyKSknghABW83LwIzNRPdrvfIf7y5nFk=,tag:KABJ2DEGoVgpqWDyl+IcxA==,type:str]
   piholeIpv4MgmtK8s00: ENC[AES256_GCM,data:UC62pO440tQlnBo=,iv:unentwg99dzrqsr+kmd4SsDCTRWkH0QwMwaBksnfWGw=,tag:Ybj1gulfHlZ/BKiQYia0/w==,type:str]
   piholeIpv6MgmtK8s00: ENC[AES256_GCM,data:RcX1j8cKRY9+j23soeytMXbtmmFuwA==,iv:IJzNxmT0fFsz725hQgIG8AZ0TPCfI2L+/jq9hr7YzZk=,tag:ZJ+xgm1LDRRWB3isXpc+Aw==,type:str]
   piholeIpv4K8s00Bootstrap00: ENC[AES256_GCM,data:qfBxfyr+pU5NJRfu,iv:kW84pgfnp/D7s7bXcz43ALR/NzH61NOU5poYDlRiEVA=,tag:Z2vxhGtK5qlQVyX3EWig8Q==,type:str]
@@ -52,6 +54,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age195m7v6w6lce8knleuc9juqwklj56vjflng64q60eh90yrfpsfyjs222pls
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-25T10:55:03Z"
-  mac: ENC[AES256_GCM,data:jUAp9mWH7dkxDnfdQKdJ68lErke4HoV/CYAp3cMRb7H43ZRqdcqjd5oOK2MUZ66x3+kS++gr0OTL90U+GO2KlcL+8EJ2rLWw2TrdVwCWqpgOTZX9AAEGiEg6+fcKJA/cSr+XZFoPeRuVEEaoammcNlLSFGzqXr2wsbGS7fkei7Y=,iv:fr1jjQmR66RoYuCOe+LLLpVjIRIRKJQiKK4to23faq4=,tag:bpOm3F+Gcb2n/A1wKRaqIQ==,type:str]
+  lastmodified: "2026-06-29T20:01:51Z"
+  mac: ENC[AES256_GCM,data:zNbdxlgwmznkpvU04LUpALMhJwc/GXfVm+dv9RGOLq4X4BlG4Jrir2YMbt1V0G1IwjY4uUGmi6+uuvUhCCu8bKjfkZH66H8s6YucOWl50hgsavCfh0+HCL/hVvHvpuYs8PPL3zxCkMbkq9/3tJBvS4D3+4FiqDtfTPVRq5/LUiA=,iv:3Lm7eVkiBhWp4yGh0KzyzHVFVTAMwBels39oL9wh27Q=,tag:XZdFEv/8W28pZE8KG9AU9w==,type:str]
   version: 3.13.1


### PR DESCRIPTION
This pull request adds new Pi-hole management DNS entries and updates encrypted IP variables to support both `bootstrap00` and `k8s00` environments. The changes ensure that both IPv4 and IPv6 addresses are properly defined and referenced for management interfaces across these environments.

**DNS Configuration Updates:**
* Added custom DNS entries for `piholemgmt.bootstrap00` and `piholemgmt.k8s00` (for both IPv4 and IPv6) in `pihole-mgmt.yaml` for both `bootstrap00` and `k8s00` clusters. [[1]](diffhunk://#diff-9821e9ef2e5616f24dc6868ebbd9ba12d7687363c0b6ea651403f6ed2aae8ff1R32-R35) [[2]](diffhunk://#diff-195c8950f420a5dd1ff5f320f5590ae12537ee26c4bce5153a05969077ddca61R36-R39)

**Encrypted Variable Additions and Updates:**
* Added encrypted values for `piholeIpv4MgmtK8s00` and `piholeIpv6MgmtK8s00` in `global.values.sops.yaml` for the `bootstrap00` cluster.
* Added encrypted values for `piholeIpv4MgmtBootstrap00` and `piholeIpv6MgmtBootstrap00` in `global.variables.sops.yaml` for the `k8s00` cluster.

**Metadata Updates:**
* Updated SOPS metadata (`lastmodified` and `mac`) in both `global.values.sops.yaml` and `global.variables.sops.yaml` to reflect the latest changes. [[1]](diffhunk://#diff-28a8f6cdd841b219e537df086be2dee093c292f88cac4b68ccf0cb309592b6bfL59-R62) [[2]](diffhunk://#diff-a1864963c08f069e3d37bdaac3d9525655e0bf861d58537f3c8b76d984ed2f87L55-R58)