### PR TITLE
chore: k8s00: immich: upgrade to 3.0.3 with pugins

### DIFF
--- a/kubernetes/apps/k8s00/immich/immich.yaml
+++ b/kubernetes/apps/k8s00/immich/immich.yaml
@@ -17,7 +17,7 @@ spec:
       interval: 1m
   values:
     image:
-      tag: v2.7.5
+      tag: v3.0.3
 
     securityContext:
       capabilities:
@@ -82,7 +82,7 @@ spec:
 
     ai:
       image:
-        tag: v2.7.5
+        tag: v3.0.3
       runtimeClass:
         enabled: true
         name: nvidia
@@ -118,7 +118,7 @@ spec:
       image:
         repository: alangrainger/immich-public-proxy
         pullPolicy: IfNotPresent
-        tag: "1.15.5"
+        tag: "3.0.2"
       podSecurityContext:
         fsGroup: ${groupId}
       securityContext:


### PR DESCRIPTION
This pull request updates the container image versions used by the Immich deployment in the Kubernetes configuration. The changes ensure that the application and its AI component are using the latest stable releases, and also update the proxy component to a newer version.

**Image version upgrades:**

* Updated the main Immich image tag from `v2.7.5` to `v3.0.3` to bring in the latest features and fixes.
* Updated the AI component image tag from `v2.7.5` to `v3.0.3` for consistency and compatibility with the main application.
* Updated the `immich-public-proxy` image tag from `1.15.5` to `3.0.2` to use the latest version of the proxy.