### PR TITLE
chore: comment external-dns for now

### DIFF
--- a/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-bootstrap00.yaml
+++ b/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-bootstrap00.yaml
@@ -1,157 +1,157 @@
----
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
-metadata:
-  name: external-dns-pihole-mgmt-bootstrap00
-  namespace: cert-manager
-spec:
-  interval: 5m
-  chart:
-    spec:
-      chart: external-dns
-      version: ">=1.21.1 <1.22.0"
-      sourceRef:
-        kind: HelmRepository
-        name: external-dns
-        namespace: cert-manager
-      interval: 1m
-  values:
-    domainFilters:
-      - ${mgmtDomainOld}
-      - ${mgmtDomain}
-    env:
-      - name: EXTERNAL_DNS_PIHOLE_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            key: EXTERNAL_DNS_PIHOLE_PASSWORD
-            name: pihole-password
-    extraArgs:
-      - --pihole-api-version=6
-      - --pihole-server=${piholeUrlMgmtBootstrap00}
-      - --pihole-tls-skip-verify
-    interval: 1m
-    namespaced: false
-    # IMPORTANT: If you have records that you manage manually in Pi-hole, set
-    # the policy to upsert-only so they do not get deleted.
-    policy: upsert-only
-    provider:
-      name: pihole
-    # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
-    # You don't need to set this flag, but if you leave it unset, you will receive warning
-    # logs when ExternalDNS attempts to create TXT records.
-    registry: noop
-    replicaCount: 1
-    service:
-      enabled: true
-      ipFamilies: []
-      ipFamilyPolicy: null
-    serviceMonitor:
-      enabled: false
-    sources:
-      - service
-      - ingress
-      # - gateway-httproute
----
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
-metadata:
-  name: external-dns-pihole-k8s00-bootstrap00
-  namespace: cert-manager
-spec:
-  interval: 5m
-  chart:
-    spec:
-      chart: external-dns
-      version: ">=1.21.1 <1.22.0"
-      sourceRef:
-        kind: HelmRepository
-        name: external-dns
-        namespace: cert-manager
-      interval: 1m
-  values:
-    domainFilters:
-      - ${serviceDomainOld}
-      - ${serviceDomain}
-      - service.${k8s00DomainOld}
-      - service.${k8s00Domain}
-    env:
-      - name: EXTERNAL_DNS_PIHOLE_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            key: EXTERNAL_DNS_PIHOLE_PASSWORD
-            name: pihole-password
-    extraArgs:
-      - --pihole-api-version=6
-      - --pihole-server=${piholeUrlK8s00Bootstrap00}
-      - --pihole-tls-skip-verify
-    interval: 1m
-    namespaced: false
-    # IMPORTANT: If you have records that you manage manually in Pi-hole, set
-    # the policy to upsert-only so they do not get deleted.
-    policy: upsert-only
-    provider:
-      name: pihole
-    # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
-    # You don't need to set this flag, but if you leave it unset, you will receive warning
-    # logs when ExternalDNS attempts to create TXT records.
-    registry: noop
-    replicaCount: 1
-    service:
-      enabled: true
-      ipFamilies: []
-      ipFamilyPolicy: null
-    serviceMonitor:
-      enabled: false
-    sources:
-      - service
-      - ingress
-      # - gateway-httproute
----
-# apiVersion: kustomize.toolkit.fluxcd.io/v1
-# kind: Kustomization
+# ---
+# apiVersion: helm.toolkit.fluxcd.io/v2
+# kind: HelmRelease
 # metadata:
-#   name: external-dns-pihole-bootstrap00
+#   name: external-dns-pihole-mgmt-bootstrap00
 #   namespace: cert-manager
 # spec:
-#   interval: 1440m
-#   retryInterval: 1m
-#   timeout: 5m
-#   sourceRef:
-#     kind: GitRepository
-#     name: external-dns
-#   path: ./kustomize
-#   targetNamespace: cert-manager
-#   prune: true
-#   wait: true
-#   patches:
-#     - patch: |
-#         - op: replace
-#           path: /metadata/name
-#           value: external-dns-pihole-bootstrap00
-#         - op: replace
-#           path: /spec/template/spec/containers/0/args
-#           value:
-#             - --source=service
-#             - --source=ingress
-#             # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
-#             # You don't need to set this flag, but if you leave it unset, you will receive warning
-#             # logs when ExternalDNS attempts to create TXT records.
-#             - --registry=noop
-#             # IMPORTANT: If you have records that you manage manually in Pi-hole, set
-#             # the policy to upsert-only so they do not get deleted.
-#             - --policy=upsert-only
-#             - --provider=pihole
-#             # Switch to pihole V6 API
-#             - --pihole-api-version=6
-#             # Change this to the actual address of your Pi-hole web server
-#             - --pihole-server=${piholeUrlMgmtBootstrap00}
-#             # - --pihole-tls-skip-verify
-#         - op: add
-#           path: /spec/template/spec/containers/0/envFrom
-#           value:
-#             - secretRef:
-#                 # Change this if you gave the secret a different name
-#                 name: pihole-password
-#       target:
-#         kind: Deployment
+#   interval: 5m
+#   chart:
+#     spec:
+#       chart: external-dns
+#       version: ">=1.21.1 <1.22.0"
+#       sourceRef:
+#         kind: HelmRepository
 #         name: external-dns
+#         namespace: cert-manager
+#       interval: 1m
+#   values:
+#     domainFilters:
+#       - ${mgmtDomainOld}
+#       - ${mgmtDomain}
+#     env:
+#       - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+#         valueFrom:
+#           secretKeyRef:
+#             key: EXTERNAL_DNS_PIHOLE_PASSWORD
+#             name: pihole-password
+#     extraArgs:
+#       - --pihole-api-version=6
+#       - --pihole-server=${piholeUrlMgmtBootstrap00}
+#       - --pihole-tls-skip-verify
+#     interval: 1m
+#     namespaced: false
+#     # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+#     # the policy to upsert-only so they do not get deleted.
+#     policy: upsert-only
+#     provider:
+#       name: pihole
+#     # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+#     # You don't need to set this flag, but if you leave it unset, you will receive warning
+#     # logs when ExternalDNS attempts to create TXT records.
+#     registry: noop
+#     replicaCount: 1
+#     service:
+#       enabled: true
+#       ipFamilies: []
+#       ipFamilyPolicy: null
+#     serviceMonitor:
+#       enabled: false
+#     sources:
+#       - service
+#       - ingress
+#       # - gateway-httproute
+# ---
+# apiVersion: helm.toolkit.fluxcd.io/v2
+# kind: HelmRelease
+# metadata:
+#   name: external-dns-pihole-k8s00-bootstrap00
+#   namespace: cert-manager
+# spec:
+#   interval: 5m
+#   chart:
+#     spec:
+#       chart: external-dns
+#       version: ">=1.21.1 <1.22.0"
+#       sourceRef:
+#         kind: HelmRepository
+#         name: external-dns
+#         namespace: cert-manager
+#       interval: 1m
+#   values:
+#     domainFilters:
+#       - ${serviceDomainOld}
+#       - ${serviceDomain}
+#       - service.${k8s00DomainOld}
+#       - service.${k8s00Domain}
+#     env:
+#       - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+#         valueFrom:
+#           secretKeyRef:
+#             key: EXTERNAL_DNS_PIHOLE_PASSWORD
+#             name: pihole-password
+#     extraArgs:
+#       - --pihole-api-version=6
+#       - --pihole-server=${piholeUrlK8s00Bootstrap00}
+#       - --pihole-tls-skip-verify
+#     interval: 1m
+#     namespaced: false
+#     # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+#     # the policy to upsert-only so they do not get deleted.
+#     policy: upsert-only
+#     provider:
+#       name: pihole
+#     # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+#     # You don't need to set this flag, but if you leave it unset, you will receive warning
+#     # logs when ExternalDNS attempts to create TXT records.
+#     registry: noop
+#     replicaCount: 1
+#     service:
+#       enabled: true
+#       ipFamilies: []
+#       ipFamilyPolicy: null
+#     serviceMonitor:
+#       enabled: false
+#     sources:
+#       - service
+#       - ingress
+#       # - gateway-httproute
+# ---
+# # apiVersion: kustomize.toolkit.fluxcd.io/v1
+# # kind: Kustomization
+# # metadata:
+# #   name: external-dns-pihole-bootstrap00
+# #   namespace: cert-manager
+# # spec:
+# #   interval: 1440m
+# #   retryInterval: 1m
+# #   timeout: 5m
+# #   sourceRef:
+# #     kind: GitRepository
+# #     name: external-dns
+# #   path: ./kustomize
+# #   targetNamespace: cert-manager
+# #   prune: true
+# #   wait: true
+# #   patches:
+# #     - patch: |
+# #         - op: replace
+# #           path: /metadata/name
+# #           value: external-dns-pihole-bootstrap00
+# #         - op: replace
+# #           path: /spec/template/spec/containers/0/args
+# #           value:
+# #             - --source=service
+# #             - --source=ingress
+# #             # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+# #             # You don't need to set this flag, but if you leave it unset, you will receive warning
+# #             # logs when ExternalDNS attempts to create TXT records.
+# #             - --registry=noop
+# #             # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+# #             # the policy to upsert-only so they do not get deleted.
+# #             - --policy=upsert-only
+# #             - --provider=pihole
+# #             # Switch to pihole V6 API
+# #             - --pihole-api-version=6
+# #             # Change this to the actual address of your Pi-hole web server
+# #             - --pihole-server=${piholeUrlMgmtBootstrap00}
+# #             # - --pihole-tls-skip-verify
+# #         - op: add
+# #           path: /spec/template/spec/containers/0/envFrom
+# #           value:
+# #             - secretRef:
+# #                 # Change this if you gave the secret a different name
+# #                 name: pihole-password
+# #       target:
+# #         kind: Deployment
+# #         name: external-dns

--- a/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-k8s00.yaml
+++ b/kubernetes/infrastructure/k8s00/external-dns/external-dns-pihole-k8s00.yaml
@@ -1,155 +1,155 @@
----
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
-metadata:
-  name: external-dns-pihole-mgmt-k8s00
-  namespace: cert-manager
-spec:
-  interval: 5m
-  chart:
-    spec:
-      chart: external-dns
-      version: ">=1.21.1 <1.22.0"
-      sourceRef:
-        kind: HelmRepository
-        name: external-dns
-        namespace: cert-manager
-      interval: 1m
-  values:
-    domainFilters:
-      - ${mgmtDomainOld}
-      - ${mgmtDomain}
-    env:
-      - name: EXTERNAL_DNS_PIHOLE_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            key: EXTERNAL_DNS_PIHOLE_PASSWORD
-            name: pihole-password
-    extraArgs:
-      - --pihole-api-version=6
-      - --pihole-server=${piholeUrlMgmtK8s00Internal}
-    interval: 1m
-    namespaced: false
-    # IMPORTANT: If you have records that you manage manually in Pi-hole, set
-    # the policy to upsert-only so they do not get deleted.
-    policy: upsert-only
-    provider:
-      name: pihole
-    # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
-    # You don't need to set this flag, but if you leave it unset, you will receive warning
-    # logs when ExternalDNS attempts to create TXT records.
-    registry: noop
-    replicaCount: 1
-    service:
-      enabled: true
-      ipFamilies: []
-      ipFamilyPolicy: null
-    serviceMonitor:
-      enabled: false
-    sources:
-      - service
-      - ingress
-      # - gateway-httproute
----
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
-metadata:
-  name: external-dns-pihole-k8s00-k8s00
-  namespace: cert-manager
-spec:
-  interval: 5m
-  chart:
-    spec:
-      chart: external-dns
-      version: ">=1.21.1 <1.22.0"
-      sourceRef:
-        kind: HelmRepository
-        name: external-dns
-        namespace: cert-manager
-      interval: 1m
-  values:
-    domainFilters:
-      - ${serviceDomainOld}
-      - ${serviceDomain}
-      - service.${k8s00DomainOld}
-      - service.${k8s00Domain}
-    env:
-      - name: EXTERNAL_DNS_PIHOLE_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            key: EXTERNAL_DNS_PIHOLE_PASSWORD
-            name: pihole-password
-    extraArgs:
-      - --pihole-api-version=6
-      - --pihole-server=${piholeUrlK8s00K8s00Internal}
-    interval: 1m
-    namespaced: false
-    # IMPORTANT: If you have records that you manage manually in Pi-hole, set
-    # the policy to upsert-only so they do not get deleted.
-    policy: upsert-only
-    provider:
-      name: pihole
-    # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
-    # You don't need to set this flag, but if you leave it unset, you will receive warning
-    # logs when ExternalDNS attempts to create TXT records.
-    registry: noop
-    replicaCount: 1
-    service:
-      enabled: true
-      ipFamilies: []
-      ipFamilyPolicy: null
-    serviceMonitor:
-      enabled: false
-    sources:
-      - service
-      - ingress
-      # - gateway-httproute
----
-# apiVersion: kustomize.toolkit.fluxcd.io/v1
-# kind: Kustomization
+# ---
+# apiVersion: helm.toolkit.fluxcd.io/v2
+# kind: HelmRelease
 # metadata:
-#   name: external-dns-pihole-k8s00
+#   name: external-dns-pihole-mgmt-k8s00
 #   namespace: cert-manager
 # spec:
-#   interval: 1440m
-#   retryInterval: 1m
-#   timeout: 5m
-#   sourceRef:
-#     kind: GitRepository
-#     name: external-dns
-#   path: ./kustomize
-#   targetNamespace: cert-manager
-#   prune: true
-#   wait: true
-#   patches:
-#     - patch: |
-#         - op: replace
-#           path: /metadata/name
-#           value: external-dns-pihole-k8s00
-#         - op: replace
-#           path: /spec/template/spec/containers/0/args
-#           value:
-#             - --source=service
-#             - --source=ingress
-#             # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
-#             # You don't need to set this flag, but if you leave it unset, you will receive warning
-#             # logs when ExternalDNS attempts to create TXT records.
-#             - --registry=noop
-#             # IMPORTANT: If you have records that you manage manually in Pi-hole, set
-#             # the policy to upsert-only so they do not get deleted.
-#             - --policy=upsert-only
-#             - --provider=pihole
-#             # Switch to pihole V6 API
-#             - --pihole-api-version=6
-#             # Change this to the actual address of your Pi-hole web server
-#             - --pihole-server=${piholeUrlMgmtK8s00}
-#             # - --pihole-tls-skip-verify
-#         - op: add
-#           path: /spec/template/spec/containers/0/envFrom
-#           value:
-#             - secretRef:
-#                 # Change this if you gave the secret a different name
-#                 name: pihole-password
-#       target:
-#         kind: Deployment
+#   interval: 5m
+#   chart:
+#     spec:
+#       chart: external-dns
+#       version: ">=1.21.1 <1.22.0"
+#       sourceRef:
+#         kind: HelmRepository
 #         name: external-dns
+#         namespace: cert-manager
+#       interval: 1m
+#   values:
+#     domainFilters:
+#       - ${mgmtDomainOld}
+#       - ${mgmtDomain}
+#     env:
+#       - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+#         valueFrom:
+#           secretKeyRef:
+#             key: EXTERNAL_DNS_PIHOLE_PASSWORD
+#             name: pihole-password
+#     extraArgs:
+#       - --pihole-api-version=6
+#       - --pihole-server=${piholeUrlMgmtK8s00Internal}
+#     interval: 1m
+#     namespaced: false
+#     # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+#     # the policy to upsert-only so they do not get deleted.
+#     policy: upsert-only
+#     provider:
+#       name: pihole
+#     # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+#     # You don't need to set this flag, but if you leave it unset, you will receive warning
+#     # logs when ExternalDNS attempts to create TXT records.
+#     registry: noop
+#     replicaCount: 1
+#     service:
+#       enabled: true
+#       ipFamilies: []
+#       ipFamilyPolicy: null
+#     serviceMonitor:
+#       enabled: false
+#     sources:
+#       - service
+#       - ingress
+#       # - gateway-httproute
+# ---
+# apiVersion: helm.toolkit.fluxcd.io/v2
+# kind: HelmRelease
+# metadata:
+#   name: external-dns-pihole-k8s00-k8s00
+#   namespace: cert-manager
+# spec:
+#   interval: 5m
+#   chart:
+#     spec:
+#       chart: external-dns
+#       version: ">=1.21.1 <1.22.0"
+#       sourceRef:
+#         kind: HelmRepository
+#         name: external-dns
+#         namespace: cert-manager
+#       interval: 1m
+#   values:
+#     domainFilters:
+#       - ${serviceDomainOld}
+#       - ${serviceDomain}
+#       - service.${k8s00DomainOld}
+#       - service.${k8s00Domain}
+#     env:
+#       - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+#         valueFrom:
+#           secretKeyRef:
+#             key: EXTERNAL_DNS_PIHOLE_PASSWORD
+#             name: pihole-password
+#     extraArgs:
+#       - --pihole-api-version=6
+#       - --pihole-server=${piholeUrlK8s00K8s00Internal}
+#     interval: 1m
+#     namespaced: false
+#     # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+#     # the policy to upsert-only so they do not get deleted.
+#     policy: upsert-only
+#     provider:
+#       name: pihole
+#     # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+#     # You don't need to set this flag, but if you leave it unset, you will receive warning
+#     # logs when ExternalDNS attempts to create TXT records.
+#     registry: noop
+#     replicaCount: 1
+#     service:
+#       enabled: true
+#       ipFamilies: []
+#       ipFamilyPolicy: null
+#     serviceMonitor:
+#       enabled: false
+#     sources:
+#       - service
+#       - ingress
+#       # - gateway-httproute
+# ---
+# # apiVersion: kustomize.toolkit.fluxcd.io/v1
+# # kind: Kustomization
+# # metadata:
+# #   name: external-dns-pihole-k8s00
+# #   namespace: cert-manager
+# # spec:
+# #   interval: 1440m
+# #   retryInterval: 1m
+# #   timeout: 5m
+# #   sourceRef:
+# #     kind: GitRepository
+# #     name: external-dns
+# #   path: ./kustomize
+# #   targetNamespace: cert-manager
+# #   prune: true
+# #   wait: true
+# #   patches:
+# #     - patch: |
+# #         - op: replace
+# #           path: /metadata/name
+# #           value: external-dns-pihole-k8s00
+# #         - op: replace
+# #           path: /spec/template/spec/containers/0/args
+# #           value:
+# #             - --source=service
+# #             - --source=ingress
+# #             # Pihole only supports A/AAAA/CNAME records so there is no mechanism to track ownership.
+# #             # You don't need to set this flag, but if you leave it unset, you will receive warning
+# #             # logs when ExternalDNS attempts to create TXT records.
+# #             - --registry=noop
+# #             # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+# #             # the policy to upsert-only so they do not get deleted.
+# #             - --policy=upsert-only
+# #             - --provider=pihole
+# #             # Switch to pihole V6 API
+# #             - --pihole-api-version=6
+# #             # Change this to the actual address of your Pi-hole web server
+# #             - --pihole-server=${piholeUrlMgmtK8s00}
+# #             # - --pihole-tls-skip-verify
+# #         - op: add
+# #           path: /spec/template/spec/containers/0/envFrom
+# #           value:
+# #             - secretRef:
+# #                 # Change this if you gave the secret a different name
+# #                 name: pihole-password
+# #       target:
+# #         kind: Deployment
+# #         name: external-dns


### PR DESCRIPTION
This pull request refactors the configuration for ExternalDNS Pi-hole Helm releases by commenting out (disabling) the active HelmRelease resources in both `external-dns-pihole-bootstrap00.yaml` and `external-dns-pihole-k8s00.yaml`, and replacing them with commented-out YAML manifests. This effectively disables the deployment of these resources while preserving their configuration for reference or future use.

The most important changes are:

**Disabling HelmRelease resources:**
* All active `HelmRelease` resources for ExternalDNS Pi-hole management and service domains are commented out in both `external-dns-pihole-bootstrap00.yaml` and `external-dns-pihole-k8s00.yaml`, preventing their deployment. [[1]](diffhunk://#diff-698d19675348778277b96816c03ef532c9c64af834085d55c8122cc6894deb5dL1-R157) [[2]](diffhunk://#diff-1d281356982cb0e51b9367d2f2dcd5621a7271544f80578dfceb35d882055c13L1-R155)

**Preserving configuration for reference:**
* The original HelmRelease YAML blocks are retained in the files as commented-out sections, ensuring that configuration details are available for future reference or re-enablement. [[1]](diffhunk://#diff-698d19675348778277b96816c03ef532c9c64af834085d55c8122cc6894deb5dL1-R157) [[2]](diffhunk://#diff-1d281356982cb0e51b9367d2f2dcd5621a7271544f80578dfceb35d882055c13L1-R155)

**Consistent approach across environments:**
* This change is applied consistently to both the bootstrap and k8s00 environments, affecting both management and service domain configurations. [[1]](diffhunk://#diff-698d19675348778277b96816c03ef532c9c64af834085d55c8122cc6894deb5dL1-R157) [[2]](diffhunk://#diff-1d281356982cb0e51b9367d2f2dcd5621a7271544f80578dfceb35d882055c13L1-R155)