### PR TITLE
fix: multus: remove quotes for checksum

### DIFF
--- a/kubernetes/infrastructure/k8s00/multus/install-cni.configmap.yaml
+++ b/kubernetes/infrastructure/k8s00/multus/install-cni.configmap.yaml
@@ -29,11 +29,11 @@ data:
     curl -LO "https://github.com/containernetworking/plugins/releases/download/v1.0.0/cni-plugins-linux-amd64-v1.0.0.tgz.sha256"
 
     # grep "cni-plugins-linux-amd64-${__version}.tgz" "cni-plugins-linux-amd64-${__version}.tgz.sha256" | sha256sum -c -
-    grep "cni-plugins-linux-amd64-v.1.0.0.tgz" "cni-plugins-linux-amd64-v1.0.0.tgz.sha256" | sha256sum -c -
+    grep cni-plugins-linux-amd64-v.1.0.0.tgz cni-plugins-linux-amd64-v1.0.0.tgz.sha256 | sha256sum -c -
 
     # tar xvfz "cni-plugins-linux-amd64-${__version}.tgz"
     tar xvfz "cni-plugins-linux-amd64-v1.0.0.tgz"
 
     # rm "cni-plugins-linux-amd64-${__version}.tgz" "cni-plugins-linux-amd64-${__version}.tgz.sha256" LICENSE README.md
-    rm "cni-plugins-linux-amd64-v1.0.0.tgz" "cni-plugins-linux-amd64-v1.0.0.tgz.sha256" LICENSE README.md
+    rm cni-plugins-linux-amd64-v1.0.0.tgz cni-plugins-linux-amd64-v1.0.0.tgz.sha256 LICENSE README.md
     find . -type f -executable -exec cp {} /host/opt/cni/bin \;


### PR DESCRIPTION
This pull request makes minor improvements to the installation script in the `install-cni.configmap.yaml` file for Multus CNI. The main changes are simplifications to the way filenames are referenced, making the script more readable and less error-prone.

- Script simplification:
  * Updated the `grep` and `rm` commands to use unquoted filenames instead of quoted strings, reducing unnecessary complexity and potential issues with shell expansion. (`kubernetes/infrastructure/k8s00/multus/install-cni.configmap.yaml`)