### PR TITLE
fix: multus: remove installing cni plugins

### DIFF
--- a/kubernetes/infrastructure/k8s00/multus/kustomization.yaml
+++ b/kubernetes/infrastructure/k8s00/multus/kustomization.yaml
@@ -24,28 +24,28 @@ patches:
                 configMap:
                   name: multus-install-cni
                   defaultMode: 0555
-  - patch: |-
-      apiVersion: apps/v1
-      kind: DaemonSet
-      metadata:
-        name: kube-multus-ds
-        namespace: kube-system
-      spec:
-        template:
-          spec:
-            initContainers:
-            - command:
-                - /scripts/install-cni.sh
-              image: alpine/k8s:1.34.3
-              name: install-cni
-              securityContext:
-                privileged: true
-              volumeMounts:
-                - mountPath: /host/opt/cni/bin
-                  mountPropagation: Bidirectional
-                  name: cnibin
-                - mountPath: /scripts
-                  name: install-cni
+  # - patch: |-
+  #     apiVersion: apps/v1
+  #     kind: DaemonSet
+  #     metadata:
+  #       name: kube-multus-ds
+  #       namespace: kube-system
+  #     spec:
+  #       template:
+  #         spec:
+  #           initContainers:
+  #           - command:
+  #               - /scripts/install-cni.sh
+  #             image: alpine/k8s:1.34.3
+  #             name: install-cni
+  #             securityContext:
+  #               privileged: true
+  #             volumeMounts:
+  #               - mountPath: /host/opt/cni/bin
+  #                 mountPropagation: Bidirectional
+  #                 name: cnibin
+  #               - mountPath: /scripts
+  #                 name: install-cni
   - patch: |-
       apiVersion: apps/v1
       kind: DaemonSet


### PR DESCRIPTION
This pull request makes a small change to the `kubernetes/infrastructure/k8s00/multus/kustomization.yaml` file, commenting out a patch that previously added an `initContainer` to the `kube-multus-ds` DaemonSet. This disables the `install-cni` initContainer from being applied without deleting the patch entirely, making it easy to restore if needed. 

* Commented out the patch that added the `install-cni` initContainer to the `kube-multus-ds` DaemonSet, effectively disabling its application.